### PR TITLE
Closed token account bug

### DIFF
--- a/nft_ingester/src/program_transformers/token/mod.rs
+++ b/nft_ingester/src/program_transformers/token/mod.rs
@@ -3,11 +3,8 @@ use blockbuster::programs::token_account::TokenProgramAccount;
 use digital_asset_types::dao::{asset, token_accounts, tokens};
 use plerkle_serialization::AccountInfo;
 use sea_orm::{
-    entity::*,
-    query::*,
-    sea_query::{OnConflict, Token},
-    ActiveValue::Set,
-    ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait,
+    entity::*, query::*, sea_query::OnConflict, ActiveValue::Set, ConnectionTrait,
+    DatabaseConnection, DbBackend, EntityTrait,
 };
 use solana_sdk::program_option::COption;
 use spl_token::state::AccountState;
@@ -23,24 +20,6 @@ pub async fn handle_token_program_account<'a, 'b, 'c>(
     let key_bytes = key.0.to_vec();
     let spl_token_program = account_update.owner().unwrap().0.to_vec();
     match &parsing_result {
-        TokenProgramAccount::EmptyAccount => {
-            let mut query =
-                token_accounts::Entity::delete_by_id(key_bytes.clone()).build(DbBackend::Postgres);
-            query.sql = format!(
-                "{} WHERE excluded.slot_updated > tokens.slot_updated",
-                query.sql
-            );
-            let exec_result = db.execute(query).await?;
-            if exec_result.rows_affected() == 0 {
-                let mut query = tokens::Entity::delete_by_id(key_bytes).build(DbBackend::Postgres);
-                query.sql = format!(
-                    "{} WHERE excluded.slot_updated > tokens.slot_updated",
-                    query.sql
-                );
-                db.execute(query).await?;
-            }
-            Ok(())
-        }
         TokenProgramAccount::TokenAccount(ta) => {
             let mint = ta.mint.to_bytes().to_vec();
             let delegate: Option<Vec<u8>> = match ta.delegate {

--- a/nft_ingester/src/program_transformers/token/mod.rs
+++ b/nft_ingester/src/program_transformers/token/mod.rs
@@ -3,8 +3,11 @@ use blockbuster::programs::token_account::TokenProgramAccount;
 use digital_asset_types::dao::{asset, token_accounts, tokens};
 use plerkle_serialization::AccountInfo;
 use sea_orm::{
-    entity::*, query::*, sea_query::OnConflict, ActiveValue::Set, ConnectionTrait,
-    DatabaseConnection, DbBackend, EntityTrait,
+    entity::*,
+    query::*,
+    sea_query::{OnConflict, Token},
+    ActiveValue::Set,
+    ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait,
 };
 use solana_sdk::program_option::COption;
 use spl_token::state::AccountState;
@@ -20,6 +23,24 @@ pub async fn handle_token_program_account<'a, 'b, 'c>(
     let key_bytes = key.0.to_vec();
     let spl_token_program = account_update.owner().unwrap().0.to_vec();
     match &parsing_result {
+        TokenProgramAccount::EmptyAccount => {
+            let mut query =
+                token_accounts::Entity::delete_by_id(key_bytes.clone()).build(DbBackend::Postgres);
+            query.sql = format!(
+                "{} WHERE excluded.slot_updated > tokens.slot_updated",
+                query.sql
+            );
+            let exec_result = db.execute(query).await?;
+            if exec_result.rows_affected() == 0 {
+                let mut query = tokens::Entity::delete_by_id(key_bytes).build(DbBackend::Postgres);
+                query.sql = format!(
+                    "{} WHERE excluded.slot_updated > tokens.slot_updated",
+                    query.sql
+                );
+                db.execute(query).await?;
+            }
+            Ok(())
+        }
         TokenProgramAccount::TokenAccount(ta) => {
             let mint = ta.mint.to_bytes().to_vec();
             let delegate: Option<Vec<u8>> = match ta.delegate {

--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -16,6 +16,7 @@ use digital_asset_types::{
     },
     json::ChainDataV1,
 };
+use log::debug;
 use num_traits::FromPrimitive;
 use plerkle_serialization::Pubkey as FBPubkey;
 use sea_orm::{
@@ -102,7 +103,16 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                     .filter(token_accounts::Column::SlotUpdated.max())
                     .one(conn)
                     .await?;
-                Ok((token, token_account))
+                debug!("TOKEN_ACCOUNT: {:?}", token_account);
+
+                let token_account2: Option<token_accounts::Model> = token_accounts::Entity::find()
+                    .filter(token_accounts::Column::Mint.eq(mint.clone()))
+                    .filter(token_accounts::Column::Amount.gt(0))
+                    .order_by(token_accounts::Column::SlotUpdated, Order::Desc)
+                    .one(conn)
+                    .await?;
+                debug!("TOKEN_ACCOUNT2: {:?}", token_account2);
+                Ok((token, token_account2))
             }
             _ => {
                 let token = tokens::Entity::find_by_id(mint.clone()).one(conn).await?;

--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -99,6 +99,7 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                 let token_account: Option<token_accounts::Model> = token_accounts::Entity::find()
                     .filter(token_accounts::Column::Mint.eq(mint.clone()))
                     .filter(token_accounts::Column::Amount.gt(0))
+                    .filter(token_accounts::Column::SlotUpdated.max())
                     .one(conn)
                     .await?;
                 Ok((token, token_account))

--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -16,7 +16,7 @@ use digital_asset_types::{
     },
     json::ChainDataV1,
 };
-use log::debug;
+use log::{debug, info};
 use num_traits::FromPrimitive;
 use plerkle_serialization::Pubkey as FBPubkey;
 use sea_orm::{
@@ -96,23 +96,15 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
             OwnerType::Single => {
                 let token: Option<tokens::Model> =
                     tokens::Entity::find_by_id(mint.clone()).one(conn).await?;
-                // query for token account associated with mint with positive balance
+                // query for token account associated with mint with positive balance with latest slot
                 let token_account: Option<token_accounts::Model> = token_accounts::Entity::find()
-                    .filter(token_accounts::Column::Mint.eq(mint.clone()))
-                    .filter(token_accounts::Column::Amount.gt(0))
-                    .filter(token_accounts::Column::SlotUpdated.max())
-                    .one(conn)
-                    .await?;
-                debug!("TOKEN_ACCOUNT: {:?}", token_account);
-
-                let token_account2: Option<token_accounts::Model> = token_accounts::Entity::find()
                     .filter(token_accounts::Column::Mint.eq(mint.clone()))
                     .filter(token_accounts::Column::Amount.gt(0))
                     .order_by(token_accounts::Column::SlotUpdated, Order::Desc)
                     .one(conn)
                     .await?;
-                debug!("TOKEN_ACCOUNT2: {:?}", token_account2);
-                Ok((token, token_account2))
+                info!("TOKEN_ACCOUNT: {:?}", token_account);
+                Ok((token, token_account))
             }
             _ => {
                 let token = tokens::Entity::find_by_id(mint.clone()).one(conn).await?;

--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -103,7 +103,6 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                     .order_by(token_accounts::Column::SlotUpdated, Order::Desc)
                     .one(conn)
                     .await?;
-                info!("TOKEN_ACCOUNT: {:?}", token_account);
                 Ok((token, token_account))
             }
             _ => {


### PR DESCRIPTION
Geyser won't pass in closed accounts, so when a token account is closed, its state is not changed in the token_accounts table. This results in multiple token_accounts having an amount of 1. 

This breaks when we reindex the metadata account, it assumed that there would be 1 token_account with the mint with balance 1. If there are multiple it might pick the wrong owner of the asset.

Solution is to query for the token_account row with the latest slot_updated. Closed accounts will not be indexed so their slot_updated will always be older, and querying for latest slot will always get the valid token_account.