### PR TITLE
feat(api): add cdn support

### DIFF
--- a/das_api/src/config.rs
+++ b/das_api/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub metrics_host: Option<String>,
     pub server_port: u16,
     pub env: Option<String>,
+    pub cdn_prefix: Option<String>,
 }
 
 pub fn load_config() -> Result<Config, DasApiError> {

--- a/digital_asset_types/src/dapi/assets_by_authority.rs
+++ b/digital_asset_types/src/dapi/assets_by_authority.rs
@@ -1,10 +1,12 @@
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
+use crate::rpc::transform::AssetTransform;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
-use super::common::{build_asset_response, create_pagination, create_sorting};
+use super::common::build_asset_response;
+use super::common::{create_pagination, create_sorting};
 
 pub async fn get_assets_by_authority(
     db: &DatabaseConnection,
@@ -14,6 +16,7 @@ pub async fn get_assets_by_authority(
     page: Option<u64>,
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
+    transform: &AssetTransform,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -26,5 +29,5 @@ pub async fn get_assets_by_authority(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination))
+    Ok(build_asset_response(assets, limit, &pagination, transform))
 }

--- a/digital_asset_types/src/dapi/assets_by_creator.rs
+++ b/digital_asset_types/src/dapi/assets_by_creator.rs
@@ -1,6 +1,8 @@
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
+use crate::rpc::transform;
+use crate::rpc::transform::AssetTransform;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
@@ -15,6 +17,7 @@ pub async fn get_assets_by_creator(
     page: Option<u64>,
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
+    transform: &AssetTransform,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -28,5 +31,5 @@ pub async fn get_assets_by_creator(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination))
+    Ok(build_asset_response(assets, limit, &pagination, transform))
 }

--- a/digital_asset_types/src/dapi/assets_by_group.rs
+++ b/digital_asset_types/src/dapi/assets_by_group.rs
@@ -1,6 +1,8 @@
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
+use crate::rpc::transform;
+use crate::rpc::transform::AssetTransform;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
@@ -14,6 +16,7 @@ pub async fn get_assets_by_group(
     page: Option<u64>,
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
+    transform: &AssetTransform,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -27,5 +30,5 @@ pub async fn get_assets_by_group(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination))
+    Ok(build_asset_response(assets, limit, &pagination, transform))
 }

--- a/digital_asset_types/src/dapi/assets_by_owner.rs
+++ b/digital_asset_types/src/dapi/assets_by_owner.rs
@@ -1,6 +1,8 @@
 use crate::dao::scopes;
+use crate::dao::FullAsset;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
+use crate::rpc::transform::AssetTransform;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
@@ -14,6 +16,7 @@ pub async fn get_assets_by_owner(
     page: Option<u64>,
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
+    transform: &AssetTransform,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sort_by);
@@ -26,5 +29,5 @@ pub async fn get_assets_by_owner(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination))
+    Ok(build_asset_response(assets, limit, &pagination, transform))
 }

--- a/digital_asset_types/src/dapi/get_asset.rs
+++ b/digital_asset_types/src/dapi/get_asset.rs
@@ -1,10 +1,17 @@
 use sea_orm::{DatabaseConnection, DbErr};
 
-use crate::{dao::scopes, rpc::Asset};
+use crate::{
+    dao::scopes,
+    rpc::{transform::AssetTransform, Asset},
+};
 
 use super::common::asset_to_rpc;
 
-pub async fn get_asset(db: &DatabaseConnection, id: Vec<u8>) -> Result<Asset, DbErr> {
+pub async fn get_asset(
+    db: &DatabaseConnection,
+    id: Vec<u8>,
+    transform: &AssetTransform,
+) -> Result<Asset, DbErr> {
     let asset = scopes::asset::get_by_id(db, id, false).await?;
-    asset_to_rpc(asset)
+    asset_to_rpc(asset, transform)
 }

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -1,7 +1,7 @@
 use super::common::{build_asset_response, create_pagination, create_sorting};
 use crate::{
-    dao::{scopes, SearchAssetsQuery},
-    rpc::{filter::AssetSorting, response::AssetList},
+    dao::{scopes, FullAsset, SearchAssetsQuery},
+    rpc::{filter::AssetSorting, response::AssetList, transform::AssetTransform, Asset},
 };
 use sea_orm::{DatabaseConnection, DbErr};
 
@@ -13,6 +13,7 @@ pub async fn search_assets(
     page: Option<u64>,
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
+    transform: &AssetTransform,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -27,5 +28,5 @@ pub async fn search_assets(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination))
+    Ok(build_asset_response(assets, limit, &pagination, &transform))
 }

--- a/digital_asset_types/src/rpc/mod.rs
+++ b/digital_asset_types/src/rpc/mod.rs
@@ -2,5 +2,6 @@ mod asset;
 
 pub mod filter;
 pub mod response;
+pub mod transform;
 
 pub use asset::*;

--- a/digital_asset_types/src/rpc/transform.rs
+++ b/digital_asset_types/src/rpc/transform.rs
@@ -1,0 +1,4 @@
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AssetTransform {
+    pub cdn_prefix: Option<String>,
+}

--- a/digital_asset_types/tests/data/infinite_fungi.json
+++ b/digital_asset_types/tests/data/infinite_fungi.json
@@ -1,0 +1,18 @@
+{
+    "animation_url": "https://arweave.net/HVOJ3bTpqMJJJtd5nW2575vPTekLa_SSDsQc7AqV_Ho?ext=mp4",
+    "attributes": [],
+    "collection": { "family": "", "name": "CH:LL" },
+    "description": "Infinite Fungi\n*****\n“Fungi are the interface organisms between life and death.”\n*****\n[CH:LL, 2022]",
+    "image": "https://arweave.net/_a4sXT6fOHI-5VHFOHLEF73wqKuZtJgE518Ciq9DGyI?ext=gif",
+    "name": "Infinite Fungi",
+    "properties": {
+        "category": "video",
+        "creators": [{ "address": "DmTb7yS95mEdJiMFhSE8pG4c5bUngBWQjSWb4YY4BR9i", "share": 100, "verified": true }],
+        "files": [
+            { "type": "video/mp4", "uri": "https://arweave.net/HVOJ3bTpqMJJJtd5nW2575vPTekLa_SSDsQc7AqV_Ho?ext=mp4" },
+            { "type": "image/gif", "uri": "https://arweave.net/_a4sXT6fOHI-5VHFOHLEF73wqKuZtJgE518Ciq9DGyI?ext=gif" }
+        ]
+    },
+    "seller_fee_basis_points": 500,
+    "symbol": ""
+}

--- a/digital_asset_types/tests/data/mad_lad.json
+++ b/digital_asset_types/tests/data/mad_lad.json
@@ -1,0 +1,30 @@
+{
+    "name": "Mad Lads #1",
+    "description": "Fock it.",
+    "symbol": "MAD",
+    "image": "https://madlads.s3.us-west-2.amazonaws.com/images/1.png",
+    "external_url": "https://madlads.com",
+    "seller_fee_basis_points": 500,
+    "attributes": [
+        { "trait_type": "Gender", "value": "Male" },
+        { "trait_type": "Type", "value": "Light" },
+        { "trait_type": "Expression", "value": "Joy" },
+        { "trait_type": "Hair", "value": "French Crop" },
+        { "trait_type": "Eyes", "value": "Closed" },
+        { "trait_type": "Clothing", "value": "Three Piece" },
+        { "trait_type": "Background", "value": "Purple" }
+    ],
+    "properties": {
+        "files": [
+            {
+                "id": "rug",
+                "uri": "https://arweave.net/qJ5B6fx5hEt4P7XbicbJQRyTcbyLaV-OQNA1KjzdqOQ/1.png",
+                "type": "image/png"
+            },
+            { "id": "portrait", "uri": "https://madlads.s3.us-west-2.amazonaws.com/images/1.png", "type": "image/png" }
+        ],
+        "category": "image",
+        "collection": { "name": "Mad Lads", "family": "MAD" },
+        "creators": [{ "address": "2RtGg6fsFiiF1EQzHqbd66AhW7R5bWeQGpTbv2UMkCdW", "share": 100 }]
+    }
+}

--- a/digital_asset_types/tests/json_parsing.rs
+++ b/digital_asset_types/tests/json_parsing.rs
@@ -10,9 +10,14 @@ use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use tokio;
 
-pub async fn test_json(uri: String) -> Content {
-    let body: serde_json::Value = reqwest::get(&uri).await.unwrap().json().await.unwrap();
+pub async fn load_test_json(file_name: &str) -> serde_json::Value {
+    let json = tokio::fs::read_to_string(format!("tests/data/{}", file_name))
+        .await
+        .unwrap();
+    serde_json::from_str(&json).unwrap()
+}
 
+pub async fn parse_offchain_json(json: serde_json::Value, cdn_prefix: Option<String>) -> Content {
     let asset_data = asset_data::Model {
         id: Keypair::new().pubkey().to_bytes().to_vec(),
         chain_data_mutability: ChainMutability::Mutable,
@@ -25,61 +30,122 @@ pub async fn test_json(uri: String) -> Content {
             uses: None,
         })
         .unwrap(),
-        metadata_url: uri,
+        metadata_url: String::from("some url"),
         metadata_mutability: Mutability::Mutable,
-        metadata: body,
+        metadata: json,
         slot_updated: 0,
     };
 
-    v1_content_from_json(&asset_data).unwrap()
+    v1_content_from_json(&asset_data, cdn_prefix).unwrap()
 }
 
 #[tokio::test]
-async fn simple_v1_content() {
-    let c =
-        test_json("https://arweave.net/pIe_btAJIcuymBjOFAmVZ3GSGPyi2yY_30kDdHmQJzs".to_string())
-            .await;
+async fn simple_content() {
+    let cdn_prefix = None;
+    let j = load_test_json("mad_lad.json").await;
+    let parsed = parse_offchain_json(j, cdn_prefix).await;
     assert_eq!(
-        c.files,
-        Some(vec![File {
-            uri: Some(
-                "https://arweave.net/UicDlez8No5ruKmQ1-Ik0x_NNxc40mT8NEGngWyXyMY".to_string()
-            ),
-            mime: None,
-            quality: None,
-            contexts: None,
-        },])
-    )
-}
-
-#[tokio::test]
-async fn more_complex_content_v1() {
-    let c =
-        test_json("https://arweave.net/gfO_TkYttQls70pTmhrdMDz9pfMUXX8hZkaoIivQjGs".to_string())
-            .await;
-    assert_eq!(
-        c.files.map(|mut s| {
-            s.sort_by_key(|f| f.uri.clone());
-            s
-        }),
+        parsed.files,
         Some(vec![
             File {
-                uri: Some(
-                    "https://arweave.net/hdtrCCqLXF2UWwf3h6YEFj8VF1ObDMGfGeQheVuXuG4".to_string()
-                ),
-                mime: None,
+                uri: Some("https://madlads.s3.us-west-2.amazonaws.com/images/1.png".to_string()),
+                mime: Some("image/png".to_string()),
                 quality: None,
                 contexts: None,
             },
             File {
                 uri: Some(
-                    "https://arweave.net/hdtrCCqLXF2UWwf3h6YEFj8VF1ObDMGfGeQheVuXuG4?ext=png"
+                    "https://arweave.net/qJ5B6fx5hEt4P7XbicbJQRyTcbyLaV-OQNA1KjzdqOQ/1.png"
                         .to_string(),
                 ),
                 mime: Some("image/png".to_string()),
                 quality: None,
                 contexts: None,
             }
+        ])
+    )
+}
+
+#[tokio::test]
+async fn simple_content_with_cdn() {
+    let cdn_prefix = Some("https://cdn.foobar.blah".to_string());
+    let j = load_test_json("mad_lad.json").await;
+    let parsed = parse_offchain_json(j, cdn_prefix).await;
+    assert_eq!(
+        parsed.files,
+        Some(vec![
+            File {
+                uri: Some("https://cdn.foobar.blah//https://madlads.s3.us-west-2.amazonaws.com/images/1.png".to_string()),
+                mime: Some("image/png".to_string()),
+                quality: None,
+                contexts: None,
+            },
+            File {
+                uri: Some(
+                    "https://cdn.foobar.blah//https://arweave.net/qJ5B6fx5hEt4P7XbicbJQRyTcbyLaV-OQNA1KjzdqOQ/1.png"
+                        .to_string(),
+                ),
+                mime: Some("image/png".to_string()),
+                quality: None,
+                contexts: None,
+            }
+        ])
+    )
+}
+
+#[tokio::test]
+async fn complex_content() {
+    let cdn_prefix = None;
+    let j = load_test_json("infinite_fungi.json").await;
+    let parsed = parse_offchain_json(j, cdn_prefix).await;
+    assert_eq!(
+        parsed.files,
+        Some(vec![
+            File {
+                uri: Some(
+                    "https://arweave.net/_a4sXT6fOHI-5VHFOHLEF73wqKuZtJgE518Ciq9DGyI?ext=gif"
+                        .to_string(),
+                ),
+                mime: Some("image/gif".to_string()),
+                quality: None,
+                contexts: None,
+            },
+            File {
+                uri: Some(
+                    "https://arweave.net/HVOJ3bTpqMJJJtd5nW2575vPTekLa_SSDsQc7AqV_Ho?ext=mp4"
+                        .to_string()
+                ),
+                mime: Some("video/mp4".to_string()),
+                quality: None,
+                contexts: None,
+            },
+        ])
+    )
+}
+
+#[tokio::test]
+async fn complex_content_with_cdn() {
+    let cdn_prefix = Some("https://cdn.foobar.blah".to_string());
+    let j = load_test_json("infinite_fungi.json").await;
+    let parsed = parse_offchain_json(j, cdn_prefix).await;
+    assert_eq!(
+        parsed.files,
+        Some(vec![
+            File {
+                uri: Some(
+                    "https://cdn.foobar.blah//https://arweave.net/_a4sXT6fOHI-5VHFOHLEF73wqKuZtJgE518Ciq9DGyI?ext=gif"
+                        .to_string(),
+                ),
+                mime: Some("image/gif".to_string()),
+                quality: None,
+                contexts: None,
+            },
+            File {
+                uri: Some("https://arweave.net/HVOJ3bTpqMJJJtd5nW2575vPTekLa_SSDsQc7AqV_Ho?ext=mp4".to_string()),
+                mime: Some("video/mp4".to_string()),
+                quality: None,
+                contexts: None,
+            },
         ])
     )
 }


### PR DESCRIPTION
Add CDN support (optional). Sort so image url is provided first in files (makes it easier for explorers) to display the right image (e.g. show mad lad instead of rug).

Testing: 
* Locally against claynos, madlads, and 1/1 nfts. 
* Verified that CDN transform is applied with and without the env var.