### PR TITLE
fix(ingester): fix compressed nft burn indexing

### DIFF
--- a/nft_ingester/src/program_transformers/bubblegum/burn.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/burn.rs
@@ -21,7 +21,7 @@ where
             &[
                 "asset".as_bytes(),
                 cl.id.as_ref(),
-                leaf_index.to_le_bytes().as_ref(),
+                u32_to_u8_array(leaf_index).as_ref(),
             ],
             &mpl_bubblegum::ID,
         );
@@ -41,4 +41,12 @@ where
     Err(IngesterError::ParsingError(
         "Ix not parsed correctly".to_string(),
     ))
+}
+
+// PDA lookup requires an 8-byte array.
+fn u32_to_u8_array(value: u32) -> [u8; 8] {
+    let bytes: [u8; 4] = value.to_le_bytes();
+    let mut result: [u8; 8] = [0; 8];
+    result[..4].copy_from_slice(&bytes);
+    result
 }

--- a/nft_ingester/src/program_transformers/bubblegum/burn.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/burn.rs
@@ -1,12 +1,9 @@
-use crate::{
-    error::IngesterError,
-};
-use super::{update_asset, save_changelog_event};
-use blockbuster::{
-    instruction::InstructionBundle,
-    programs::bubblegum::{BubblegumInstruction, LeafSchema},
-};
+use super::{save_changelog_event, update_asset};
+use crate::error::IngesterError;
+use anchor_lang::prelude::Pubkey;
+use blockbuster::{instruction::InstructionBundle, programs::bubblegum::BubblegumInstruction};
 use digital_asset_types::dao::asset;
+use log::debug;
 use sea_orm::{entity::*, ConnectionTrait, TransactionTrait};
 
 pub async fn burn<'c, T>(
@@ -17,23 +14,29 @@ pub async fn burn<'c, T>(
 where
     T: ConnectionTrait + TransactionTrait,
 {
-    if let (Some(le), Some(cl)) = (&parsing_result.leaf_update, &parsing_result.tree_update) {
+    if let Some(cl) = &parsing_result.tree_update {
         let seq = save_changelog_event(cl, bundle.slot, txn).await?;
-        return match le.schema {
-            LeafSchema::V1 { id, .. } => {
-                let id_bytes = id.to_bytes().to_vec();
-                let asset_to_update = asset::ActiveModel {
-                    id: Unchanged(id_bytes.clone()),
-                    burnt: Set(true),
-                    seq: Set(seq as i64), // gummyroll seq
-                    ..Default::default()
-                };
-                // Don't send sequence number with this update, because we will always
-                // run this update even if it's from a backfill/replay.
-                update_asset(txn, id_bytes, None, asset_to_update).await
-            }
-            _ => Err(IngesterError::NotImplemented),
+        let leaf_index = cl.index;
+        let (asset_id, _) = Pubkey::find_program_address(
+            &[
+                "asset".as_bytes(),
+                cl.id.as_ref(),
+                leaf_index.to_le_bytes().as_ref(),
+            ],
+            &mpl_bubblegum::ID,
+        );
+        debug!("Indexing burn for asset id: {:?}", asset_id);
+        let id_bytes = asset_id.to_bytes().to_vec();
+        let asset_to_update = asset::ActiveModel {
+            id: Unchanged(id_bytes.clone()),
+            burnt: Set(true),
+            seq: Set(seq as i64),
+            ..Default::default()
         };
+        // Don't send sequence number with this update, because we will always
+        // run this update even if it's from a backfill/replay.
+        update_asset(txn, id_bytes, None, asset_to_update).await?;
+        return Ok(());
     }
     Err(IngesterError::ParsingError(
         "Ix not parsed correctly".to_string(),


### PR DESCRIPTION
## Overview
* Burns were failing to parse and breaking trees.
* The issue is that the burn ix does not include the leaf schema like other txns.
    * Burn ix: https://github.com/metaplex-foundation/metaplex-program-library/blob/master/bubblegum/program/src/lib.rs#L1296
    * Compared to a transfer, which includes leaf schema via the application data function: https://github.com/metaplex-foundation/metaplex-program-library/blob/master/bubblegum/program/src/lib.rs#L1232
    * The outcome is that `parsing_result.leaf_update` was always empty and no indexing happened.
    * The fix is to derive the necessary data from the tree update instead.

## Testing
* Locally against tree with broken nft indexing (txn example: 4nmSHdMHAS7gKqYDt3fP8MSKK9XE2Qfg8HuZWTw1d9xwkJjQ94WmAoNKDAaaqMLRBdPRw4VpedpQJ9ZMm35MZh6B)