### PR TITLE
feat(api): expose burnt field

### DIFF
--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -445,6 +445,7 @@ pub fn asset_to_rpc(asset: FullAsset, transform: &AssetTransform) -> Result<RpcA
             total: u.get("total").and_then(|t| t.as_u64()).unwrap_or(0),
             remaining: u.get("remaining").and_then(|t| t.as_u64()).unwrap_or(0),
         }),
+        burnt: asset.burnt,
     })
 }
 

--- a/digital_asset_types/src/rpc/asset.rs
+++ b/digital_asset_types/src/rpc/asset.rs
@@ -358,4 +358,5 @@ pub struct Asset {
     pub uses: Option<Uses>,
     pub supply: Option<Supply>,
     pub mutable: bool,
+    pub burnt: bool,
 }


### PR DESCRIPTION
Tested locally against all endpoints, both burned and non-burned cNFTs.