### PR TITLE
fix: make `delegate` string

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -314,6 +314,7 @@ impl ApiContract for DasApi {
         });
         let owner_address = validate_opt_pubkey(&owner_address)?;
         let creator_address = validate_opt_pubkey(&creator_address)?;
+        let delegate = validate_opt_pubkey(&delegate)?;
 
         let authority_address = validate_opt_pubkey(&authority_address)?;
         let supply_mint = validate_opt_pubkey(&supply_mint)?;

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -64,7 +64,7 @@ pub struct SearchAssets {
     pub creator_verified: Option<bool>,
     pub authority_address: Option<String>,
     pub grouping: Option<(String, String)>,
-    pub delegate: Option<Vec<u8>>,
+    pub delegate: Option<String>,
     pub frozen: Option<bool>,
     pub supply: Option<u64>,
     pub supply_mint: Option<String>,


### PR DESCRIPTION
## Overview

-   Previously, `delegate` used to be `Vec<u8>`, but in practice it should be a `String` so that users can provide a valid address.

## Testing

-   Testing performed to validate the changes
