### PR TITLE
fix: token indexing

### DIFF
--- a/nft_ingester/src/program_transformers/token/mod.rs
+++ b/nft_ingester/src/program_transformers/token/mod.rs
@@ -1,7 +1,9 @@
 use crate::{error::IngesterError, tasks::TaskData};
 use blockbuster::programs::token_account::TokenProgramAccount;
 use cadence_macros::statsd_count;
-use digital_asset_types::dao::{asset, asset_data, token_accounts, tokens};
+use digital_asset_types::dao::{
+    asset, asset_data, sea_orm_active_enums::OwnerType, token_accounts, tokens,
+};
 use log::error;
 use plerkle_serialization::AccountInfo;
 use sea_orm::{
@@ -68,39 +70,80 @@ pub async fn handle_token_program_account<'a, 'b, 'c>(
                 query.sql
             );
             db.execute(query).await?;
-            let txn = db.begin().await?;
 
+            // Metrics
+            let mut metadata_url_exists = false;
+            let mut token_owner_update = false;
+            let mut token_delegate_update = false;
+            let mut token_freeze_update = false;
+
+            let txn = db.begin().await?;
             let asset_with_data = asset::Entity::find_by_id(mint)
                 .filter(asset::Column::OwnerType.eq("single"))
                 .find_also_related(asset_data::Entity)
                 .one(&txn)
                 .await?;
 
-            let owner_clone = owner.clone();
             if let Some((asset, data)) = asset_with_data {
-                // will only update owner if token account balance is non-zero
-                if ta.amount > 0 {
-                    if asset.owner != Some(owner_clone)
-                        || asset.delegate != delegate
-                        || asset.frozen != frozen
-                    {
-                        let mut active: asset::ActiveModel = asset.into();
-                        active.owner = Set(Some(owner));
-                        active.delegate = Set(delegate);
-                        active.frozen = Set(frozen);
-                        active.save(&txn).await?;
+                if let Some(data) = data {
+                    if !data.metadata_url.is_empty() {
+                        metadata_url_exists = true;
+                    }
+                }
 
-                        if let Some(data) = data {
-                            if data.metadata_url.is_empty() {
-                                statsd_count!("token_account.empty_url", 1);
-                            } else {
-                                statsd_count!("token_account.non_empty_url", 1);
-                            }
-                        }
+                // Only handle token account updates for NFTs (supply=1)
+                // TODO: Support fungible tokens
+                let asset_clone = asset.clone();
+                if asset_clone.supply == 1 {
+                    let mut save_required = false;
+                    let mut active: asset::ActiveModel = asset.into();
+
+                    // Handle ownership updates
+                    let old_owner = asset_clone.owner.clone();
+                    let new_owner = owner.clone();
+                    if ta.amount > 0 && Some(new_owner) != old_owner {
+                        active.owner = Set(Some(owner.clone()));
+                        token_owner_update = true;
+                        save_required = true;
+                    }
+
+                    // Handle delegate updates
+                    if ta.amount > 0 && delegate.clone() != asset_clone.delegate {
+                        active.delegate = Set(delegate.clone());
+                        token_delegate_update = true;
+                        save_required = true;
+                    }
+
+                    // Handle freeze updates
+                    if ta.amount > 0 && frozen != asset_clone.frozen {
+                        active.frozen = Set(frozen);
+                        token_freeze_update = true;
+                        save_required = true;
+                    }
+
+                    if save_required {
+                        active.save(&txn).await?;
                     }
                 }
             }
             txn.commit().await?;
+
+            // Publish metrics outside of the txn to reduce txn latency.
+            if metadata_url_exists {
+                statsd_count!("token_account.non_empty_url", 1);
+            } else {
+                statsd_count!("token_account.empty_url", 1);
+            }
+            if token_owner_update {
+                statsd_count!("token_account.owner_update", 1);
+            }
+            if token_delegate_update {
+                statsd_count!("token_account.delegate_update", 1);
+            }
+            if token_freeze_update {
+                statsd_count!("token_account.freeze_update", 1);
+            }
+
             Ok(())
         }
         TokenProgramAccount::Mint(m) => {


### PR DESCRIPTION
## Overview

-   Only update token indexes for NFTs, to reduce load.
-   Add metrics for delegate/freezing. In the future we may want to make the conditions for updating delegates/freezes different.

## Testing

-   N/A, needs to be tested by @nikhil-helius before deploying
