### PR TITLE
feat: add optional args `tree` and `leafIndex` for decompressed assets

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -414,12 +414,12 @@ impl ApiContract for DasApi {
         get_signatures_for_asset(
             &self.db_connection,
             id,
+            tree,
+            leaf_index,
             limit.map(|x| x as u64).unwrap_or(1000),
             page.map(|x| x as u64),
             before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
-            tree,
-            leaf_index,
         )
         .await
         .map_err(Into::into)

--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -401,7 +401,9 @@ impl ApiContract for DasApi {
             leaf_index,
         } = payload;
 
-        if id.is_none() && (tree.is_none() || leaf_index.is_none()) {
+        if !((id.is_some() && tree.is_none() && leaf_index.is_none())
+            || (id.is_none() && tree.is_some() && leaf_index.is_some()))
+        {
             return Err(DasApiError::ValidationError(
                 "Must provide either 'id' or both 'tree' and 'leafIndex'".to_string(),
             ));

--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -398,17 +398,16 @@ impl ApiContract for DasApi {
             before,
             after,
             tree,
-            leaf_id,
+            leaf_index,
         } = payload;
 
-        if id.is_none() && (tree.is_none() || leaf_id.is_none()) {
+        if id.is_none() && (tree.is_none() || leaf_index.is_none()) {
             return Err(DasApiError::ValidationError(
-                "Must provide either id or both tree and leaf_id".to_string(),
+                "Must provide either 'id' or both 'tree' and 'leafIndex'".to_string(),
             ));
         }
         let id = validate_opt_pubkey(&id)?;
         let tree = validate_opt_pubkey(&tree)?;
-        let leaf_id = validate_opt_pubkey(&leaf_id)?;
 
         self.validate_pagination(&limit, &page, &before, &after)?;
 
@@ -420,7 +419,7 @@ impl ApiContract for DasApi {
             before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             tree,
-            leaf_id,
+            leaf_index,
         )
         .await
         .map_err(Into::into)

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -105,11 +105,13 @@ pub struct GetGrouping {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct GetSignaturesForAsset {
-    pub id: String,
+    pub id: Option<String>,
     pub limit: Option<u32>,
     pub page: Option<u32>,
     pub before: Option<String>,
     pub after: Option<String>,
+    pub tree: Option<String>,
+    pub leaf_id: Option<String>,
 }
 
 #[document_rpc]

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -111,7 +111,7 @@ pub struct GetSignaturesForAsset {
     pub before: Option<String>,
     pub after: Option<String>,
     pub tree: Option<String>,
-    pub leaf_id: Option<String>,
+    pub leaf_index: Option<i64>,
 }
 
 #[document_rpc]

--- a/das_api/src/main.rs
+++ b/das_api/src/main.rs
@@ -4,7 +4,7 @@ mod config;
 mod error;
 mod validation;
 
-use std::time::{Instant};
+use std::time::Instant;
 use {
     crate::api::DasApi,
     crate::builder::RpcApiBuilder,
@@ -17,7 +17,7 @@ use {
     std::net::UdpSocket,
 };
 
-use hyper::{Method};
+use hyper::Method;
 use log::{debug, info};
 use tower_http::cors::{Any, CorsLayer};
 

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -324,11 +324,12 @@ pub async fn fetch_transactions(
 pub async fn get_signatures_for_asset(
     conn: &impl ConnectionTrait,
     asset_id: Option<Vec<u8>>,
-    pagination: &Pagination,
-    limit: u64,
     tree_id: Option<Vec<u8>>,
     leaf_idx: Option<i64>,
+    pagination: &Pagination,
+    limit: u64,
 ) -> Result<Vec<Vec<String>>, DbErr> {
+    // if tree_id and leaf_idx are provided, use them directly to fetch transactions
     if let (Some(tree_id), Some(leaf_idx)) = (tree_id, leaf_idx) {
         let transactions = fetch_transactions(conn, tree_id, leaf_idx, pagination, limit).await?;
         return Ok(transactions);
@@ -340,6 +341,8 @@ pub async fn get_signatures_for_asset(
         ));
     }
 
+    // if only asset_id is provided, fetch the latest tree and leaf_idx (asset.nonce) for the asset
+    // and use them to fetch transactions
     let stmt = asset::Entity::find()
         .distinct_on([(asset::Entity, asset::Column::Id)])
         .filter(asset::Column::Id.eq(asset_id))

--- a/digital_asset_types/src/dapi/signatures_for_asset.rs
+++ b/digital_asset_types/src/dapi/signatures_for_asset.rs
@@ -14,11 +14,11 @@ pub async fn get_signatures_for_asset(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     tree: Option<Vec<u8>>,
-    leaf_id: Option<Vec<u8>>,
+    leaf_idx: Option<i64>,
 ) -> Result<TransactionSignatureList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let transactions =
-        scopes::asset::get_signatures_for_asset(db, asset_id, &pagination, limit, tree, leaf_id)
+        scopes::asset::get_signatures_for_asset(db, asset_id, &pagination, limit, tree, leaf_idx)
             .await?;
     Ok(build_transaction_signatures_response(
         transactions,

--- a/digital_asset_types/src/dapi/signatures_for_asset.rs
+++ b/digital_asset_types/src/dapi/signatures_for_asset.rs
@@ -9,12 +9,12 @@ use super::common::{build_transaction_signatures_response, create_pagination};
 pub async fn get_signatures_for_asset(
     db: &DatabaseConnection,
     asset_id: Option<Vec<u8>>,
+    tree: Option<Vec<u8>>,
+    leaf_idx: Option<i64>,
     limit: u64,
     page: Option<u64>,
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
-    tree: Option<Vec<u8>>,
-    leaf_idx: Option<i64>,
 ) -> Result<TransactionSignatureList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let transactions =

--- a/digital_asset_types/src/dapi/signatures_for_asset.rs
+++ b/digital_asset_types/src/dapi/signatures_for_asset.rs
@@ -18,7 +18,7 @@ pub async fn get_signatures_for_asset(
 ) -> Result<TransactionSignatureList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let transactions =
-        scopes::asset::get_signatures_for_asset(db, asset_id, &pagination, limit, tree, leaf_idx)
+        scopes::asset::get_signatures_for_asset(db, asset_id, tree, leaf_idx, &pagination, limit)
             .await?;
     Ok(build_transaction_signatures_response(
         transactions,

--- a/digital_asset_types/src/dapi/signatures_for_asset.rs
+++ b/digital_asset_types/src/dapi/signatures_for_asset.rs
@@ -8,15 +8,18 @@ use super::common::{build_transaction_signatures_response, create_pagination};
 
 pub async fn get_signatures_for_asset(
     db: &DatabaseConnection,
-    asset_id: Vec<u8>,
+    asset_id: Option<Vec<u8>>,
     limit: u64,
     page: Option<u64>,
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
+    tree: Option<Vec<u8>>,
+    leaf_id: Option<Vec<u8>>,
 ) -> Result<TransactionSignatureList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let transactions =
-        scopes::asset::get_signatures_for_asset(db, asset_id, &pagination, limit).await?;
+        scopes::asset::get_signatures_for_asset(db, asset_id, &pagination, limit, tree, leaf_id)
+            .await?;
     Ok(build_transaction_signatures_response(
         transactions,
         limit,

--- a/nft_ingester/src/account_updates.rs
+++ b/nft_ingester/src/account_updates.rs
@@ -1,10 +1,7 @@
-use std::{
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use crate::{
-    metric, metrics::capture_result,
-    program_transformers::ProgramTransformer, tasks::TaskData,
+    metric, metrics::capture_result, program_transformers::ProgramTransformer, tasks::TaskData,
 };
 use cadence_macros::{is_global_default_set, statsd_count, statsd_time};
 use chrono::Utc;

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -47,7 +47,7 @@ pub async fn main() -> Result<(), IngesterError> {
     let role = config.clone().role.unwrap_or(IngesterRole::All);
     info!("Starting Program with Role {}", role);
     // Tasks Setup -----------------------------------------------
-    // This joinset maages all the tasks that are spawned.
+    // This joinSet manages all the tasks that are spawned.
     let mut tasks = JoinSet::new();
     let stream_metrics_timer = Duration::seconds(30).to_std().unwrap();
 


### PR DESCRIPTION
## Overview

-   For decompressed assets, the `asset` table does not contain a `tree` id. So we provide optional args `tree` and `leafIndex` to query decompressed assets

## Testing

-   Testing performed locally to validate the changes
