### PR TITLE
fix(ingester): do not ACK retryable errors

### DIFF
--- a/nft_ingester/Cargo.lock
+++ b/nft_ingester/Cargo.lock
@@ -3141,6 +3141,8 @@ dependencies = [
  "async-mutex",
  "async-trait",
  "blake3",
+ "cadence",
+ "cadence-macros",
  "figment",
  "futures",
  "log",

--- a/nft_ingester/src/account_updates.rs
+++ b/nft_ingester/src/account_updates.rs
@@ -94,8 +94,8 @@ async fn handle_account(manager: Arc<ProgramTransformer>, item: RecvData) -> Opt
         }
         let begin_processing = Instant::now();
         let res = manager.handle_account_update(account_update).await;
-        ret_id = capture_result(
-            id,
+        let should_ack = capture_result(
+            id.clone(),
             ACCOUNT_STREAM,
             ("owner", &str_program_id),
             item.tries,
@@ -104,6 +104,9 @@ async fn handle_account(manager: Arc<ProgramTransformer>, item: RecvData) -> Opt
             None,
             account,
         );
+        if should_ack {
+            ret_id = Some(id);
+        }
     }
     ret_id
 }

--- a/nft_ingester/src/transaction_notifications.rs
+++ b/nft_ingester/src/transaction_notifications.rs
@@ -93,8 +93,8 @@ async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) ->
 
         let begin = Instant::now();
         let res = manager.handle_transaction(&tx).await;
-        ret_id = capture_result(
-            id,
+        let should_ack = capture_result(
+            id.clone(),
             TRANSACTION_STREAM,
             ("txn", "txn"),
             item.tries,
@@ -103,6 +103,9 @@ async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) ->
             tx.signature(),
             None,
         );
+        if should_ack {
+            ret_id = Some(id);
+        }
     }
     ret_id
 }


### PR DESCRIPTION
## Overview

-   After adding some new metrics we were accidentally ACKing retryable errors, preventing retries. Note that retries were also broken in the redis messenger. These are fixed here: https://github.com/helius-labs/digital-asset-validator-plugin/pull/7. 
-   Refactored the code to make this more obvious to prevent future innocent mistakes.

## Testing

-   e2e tested in dev and ensured
