### PR TITLE
fix: indexing burnt ACC updates

### DIFF
--- a/nft_ingester/Cargo.lock
+++ b/nft_ingester/Cargo.lock
@@ -755,6 +755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,11 +3150,13 @@ dependencies = [
  "async-mutex",
  "async-trait",
  "blake3",
+ "bs58 0.5.0",
  "cadence",
  "cadence-macros",
  "figment",
  "futures",
  "log",
+ "plerkle_serialization 1.5.3",
  "redis",
  "serde",
  "thiserror",


### PR DESCRIPTION
## Overview
-   Previously, if we tried to index a reg NFT which wasn't previously indexed, it'd return the error: `StorageWriteError("Execution Error: error returned from database: null value in column \"specification_version\" of relation \"asset\" violates not-null constraint")`. This PR fixes this.

## Testing
-   Testing performed to validate the changes.
