### PR TITLE
feat: add `total` number of assets that match the query

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use digital_asset_types::{
     dao::{
         scopes::asset::get_grouping,
@@ -34,6 +36,7 @@ use {
 pub struct DasApi {
     db_connection: DatabaseConnection,
     cdn_prefix: Option<String>,
+    flags: HashMap<String, bool>,
 }
 
 impl DasApi {
@@ -42,11 +45,12 @@ impl DasApi {
             .max_connections(250)
             .connect(&config.database_url)
             .await?;
-
+        let flags = get_flags(&config);
         let conn = SqlxPostgresConnector::from_sqlx_postgres_pool(pool);
         Ok(DasApi {
             db_connection: conn,
             cdn_prefix: config.cdn_prefix,
+            flags,
         })
     }
 
@@ -89,6 +93,15 @@ impl DasApi {
 
         Ok(())
     }
+}
+
+fn get_flags(config: &Config) -> HashMap<String, bool> {
+    let mut flags = HashMap::new();
+    flags.insert(
+        "grand_total_flag".to_string(),
+        config.grand_total_flag.unwrap_or(false),
+    );
+    flags
 }
 
 pub fn not_found(asset_id: &String) -> DbErr {
@@ -166,6 +179,7 @@ impl ApiContract for DasApi {
             before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             &transform,
+            &self.flags,
         )
         .await
         .map_err(Into::into)
@@ -201,6 +215,7 @@ impl ApiContract for DasApi {
             before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             &transform,
+            &self.flags,
         )
         .await
         .map_err(Into::into)
@@ -238,6 +253,7 @@ impl ApiContract for DasApi {
             before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             &transform,
+            &self.flags,
         )
         .await
         .map_err(Into::into)
@@ -271,6 +287,7 @@ impl ApiContract for DasApi {
             before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             &transform,
+            &self.flags,
         )
         .await
         .map_err(Into::into)
@@ -369,6 +386,7 @@ impl ApiContract for DasApi {
             before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             &transform,
+            &self.flags,
         )
         .await
         .map_err(Into::into)

--- a/das_api/src/config.rs
+++ b/das_api/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub server_port: u16,
     pub env: Option<String>,
     pub cdn_prefix: Option<String>,
+    pub grand_total_flag: Option<bool>, // export APP_GRAND_TOTAL_FLAG=true;
 }
 
 pub fn load_config() -> Result<Config, DasApiError> {

--- a/das_api/src/config.rs
+++ b/das_api/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
     pub server_port: u16,
     pub env: Option<String>,
     pub cdn_prefix: Option<String>,
-    pub grand_total_flag: Option<bool>,
+    pub enable_grand_total_query: Option<bool>,
 }
 
 pub fn load_config() -> Result<Config, DasApiError> {

--- a/das_api/src/config.rs
+++ b/das_api/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
     pub server_port: u16,
     pub env: Option<String>,
     pub cdn_prefix: Option<String>,
-    pub grand_total_flag: Option<bool>, // export APP_GRAND_TOTAL_FLAG=true;
+    pub grand_total_flag: Option<bool>,
 }
 
 pub fn load_config() -> Result<Config, DasApiError> {

--- a/das_api/src/feature_flag.rs
+++ b/das_api/src/feature_flag.rs
@@ -1,0 +1,11 @@
+use crate::config::Config;
+
+pub struct FeatureFlags {
+    pub enable_grand_total_query: bool,
+}
+
+pub fn get_feature_flags(config: &Config) -> FeatureFlags {
+    FeatureFlags {
+        enable_grand_total_query: config.enable_grand_total_query.unwrap_or(false),
+    }
+}

--- a/das_api/src/main.rs
+++ b/das_api/src/main.rs
@@ -2,6 +2,7 @@ pub mod api;
 mod builder;
 mod config;
 mod error;
+mod feature_flag;
 mod validation;
 
 use std::time::Instant;

--- a/digital_asset_types/src/dapi/assets_by_authority.rs
+++ b/digital_asset_types/src/dapi/assets_by_authority.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
@@ -19,7 +17,7 @@ pub async fn get_assets_by_authority(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
-    flags: &HashMap<String, bool>,
+    enable_grand_total_query: bool,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -30,7 +28,7 @@ pub async fn get_assets_by_authority(
         sort_direction,
         &pagination,
         limit,
-        flags,
+        enable_grand_total_query,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/assets_by_authority.rs
+++ b/digital_asset_types/src/dapi/assets_by_authority.rs
@@ -20,7 +20,7 @@ pub async fn get_assets_by_authority(
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
-    let assets = scopes::asset::get_by_authority(
+    let (assets, grand_total) = scopes::asset::get_by_authority(
         db,
         authority,
         sort_column,
@@ -29,5 +29,11 @@ pub async fn get_assets_by_authority(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination, transform))
+    Ok(build_asset_response(
+        assets,
+        limit,
+        grand_total,
+        &pagination,
+        transform,
+    ))
 }

--- a/digital_asset_types/src/dapi/assets_by_authority.rs
+++ b/digital_asset_types/src/dapi/assets_by_authority.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
@@ -17,6 +19,7 @@ pub async fn get_assets_by_authority(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
+    flags: &HashMap<String, bool>,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -27,6 +30,7 @@ pub async fn get_assets_by_authority(
         sort_direction,
         &pagination,
         limit,
+        flags,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/assets_by_creator.rs
+++ b/digital_asset_types/src/dapi/assets_by_creator.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
@@ -20,7 +18,7 @@ pub async fn get_assets_by_creator(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
-    flags: &HashMap<String, bool>,
+    enable_grand_total_query: bool,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -32,7 +30,7 @@ pub async fn get_assets_by_creator(
         sort_direction,
         &pagination,
         limit,
-        flags,
+        enable_grand_total_query,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/assets_by_creator.rs
+++ b/digital_asset_types/src/dapi/assets_by_creator.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
@@ -18,6 +20,7 @@ pub async fn get_assets_by_creator(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
+    flags: &HashMap<String, bool>,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -29,6 +32,7 @@ pub async fn get_assets_by_creator(
         sort_direction,
         &pagination,
         limit,
+        flags,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/assets_by_creator.rs
+++ b/digital_asset_types/src/dapi/assets_by_creator.rs
@@ -21,7 +21,7 @@ pub async fn get_assets_by_creator(
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
-    let assets = scopes::asset::get_by_creator(
+    let (assets, grand_total) = scopes::asset::get_by_creator(
         db,
         creator,
         only_verified,
@@ -31,5 +31,11 @@ pub async fn get_assets_by_creator(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination, transform))
+    Ok(build_asset_response(
+        assets,
+        limit,
+        grand_total,
+        &pagination,
+        transform,
+    ))
 }

--- a/digital_asset_types/src/dapi/assets_by_group.rs
+++ b/digital_asset_types/src/dapi/assets_by_group.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
@@ -17,6 +19,7 @@ pub async fn get_assets_by_group(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
+    flags: &HashMap<String, bool>,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -28,6 +31,7 @@ pub async fn get_assets_by_group(
         sort_direction,
         &pagination,
         limit,
+        flags,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/assets_by_group.rs
+++ b/digital_asset_types/src/dapi/assets_by_group.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::dao::scopes;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
@@ -19,7 +17,7 @@ pub async fn get_assets_by_group(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
-    flags: &HashMap<String, bool>,
+    enable_grand_total_query: bool,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -31,7 +29,7 @@ pub async fn get_assets_by_group(
         sort_direction,
         &pagination,
         limit,
-        flags,
+        enable_grand_total_query,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/assets_by_group.rs
+++ b/digital_asset_types/src/dapi/assets_by_group.rs
@@ -20,7 +20,7 @@ pub async fn get_assets_by_group(
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
-    let assets = scopes::asset::get_by_grouping(
+    let (assets, grand_total) = scopes::asset::get_by_grouping(
         db,
         group_key,
         group_value,
@@ -30,5 +30,11 @@ pub async fn get_assets_by_group(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination, transform))
+    Ok(build_asset_response(
+        assets,
+        limit,
+        grand_total,
+        &pagination,
+        transform,
+    ))
 }

--- a/digital_asset_types/src/dapi/assets_by_owner.rs
+++ b/digital_asset_types/src/dapi/assets_by_owner.rs
@@ -20,7 +20,7 @@ pub async fn get_assets_by_owner(
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sort_by);
-    let assets = scopes::asset::get_assets_by_owner(
+    let (assets, grand_total) = scopes::asset::get_assets_by_owner(
         db,
         owner_address,
         sort_column,
@@ -29,5 +29,11 @@ pub async fn get_assets_by_owner(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination, transform))
+    Ok(build_asset_response(
+        assets,
+        limit,
+        grand_total,
+        &pagination,
+        transform,
+    ))
 }

--- a/digital_asset_types/src/dapi/assets_by_owner.rs
+++ b/digital_asset_types/src/dapi/assets_by_owner.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::dao::scopes;
 
 use crate::rpc::filter::AssetSorting;
@@ -20,7 +18,7 @@ pub async fn get_assets_by_owner(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
-    flags: &HashMap<String, bool>,
+    enable_grand_total_query: bool,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sort_by);
@@ -31,7 +29,7 @@ pub async fn get_assets_by_owner(
         sort_direction,
         &pagination,
         limit,
-        flags,
+        enable_grand_total_query,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/assets_by_owner.rs
+++ b/digital_asset_types/src/dapi/assets_by_owner.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+
 use crate::dao::scopes;
 
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
 use crate::rpc::transform::AssetTransform;
+
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
@@ -17,6 +20,7 @@ pub async fn get_assets_by_owner(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
+    flags: &HashMap<String, bool>,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sort_by);
@@ -27,6 +31,7 @@ pub async fn get_assets_by_owner(
         sort_direction,
         &pagination,
         limit,
+        flags,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -64,7 +64,7 @@ pub fn build_asset_response(
     };
     let (items, errors) = asset_list_to_rpc(assets, transform);
     AssetList {
-        // grand_total: grand_total.unwrap(), // TODO: Add this back in
+        // grand_total: grand_total.unwrap(), // TODO
         total,
         limit: limit as u32,
         page: page.map(|x| x as u32),

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -49,7 +49,7 @@ pub fn file_from_str(str: String) -> File {
 pub fn build_asset_response(
     assets: Vec<FullAsset>,
     limit: u64,
-    grand_total: u64,
+    grand_total: Option<u64>,
     pagination: &Pagination,
     transform: &AssetTransform,
 ) -> AssetList {
@@ -64,7 +64,7 @@ pub fn build_asset_response(
     };
     let (items, errors) = asset_list_to_rpc(assets, transform);
     AssetList {
-        grand_total,
+        grand_total: grand_total.unwrap_or(9999999), // TODO: Remove this from responses
         total,
         limit: limit as u32,
         page: page.map(|x| x as u32),

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -49,7 +49,7 @@ pub fn file_from_str(str: String) -> File {
 pub fn build_asset_response(
     assets: Vec<FullAsset>,
     limit: u64,
-    _grand_total: Option<u64>,
+    grand_total: Option<u64>,
     pagination: &Pagination,
     transform: &AssetTransform,
 ) -> AssetList {

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -49,7 +49,7 @@ pub fn file_from_str(str: String) -> File {
 pub fn build_asset_response(
     assets: Vec<FullAsset>,
     limit: u64,
-    grand_total: Option<u64>,
+    _grand_total: Option<u64>,
     pagination: &Pagination,
     transform: &AssetTransform,
 ) -> AssetList {
@@ -64,7 +64,7 @@ pub fn build_asset_response(
     };
     let (items, errors) = asset_list_to_rpc(assets, transform);
     AssetList {
-        grand_total: grand_total.unwrap_or(9999999), // TODO: Remove this from responses
+        // grand_total: grand_total.unwrap(), // TODO: Add this back in
         total,
         limit: limit as u32,
         page: page.map(|x| x as u32),

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -49,6 +49,7 @@ pub fn file_from_str(str: String) -> File {
 pub fn build_asset_response(
     assets: Vec<FullAsset>,
     limit: u64,
+    grand_total: u64,
     pagination: &Pagination,
     transform: &AssetTransform,
 ) -> AssetList {
@@ -63,6 +64,7 @@ pub fn build_asset_response(
     };
     let (items, errors) = asset_list_to_rpc(assets, transform);
     AssetList {
+        grand_total,
         total,
         limit: limit as u32,
         page: page.map(|x| x as u32),

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::common::{build_asset_response, create_pagination, create_sorting};
 use crate::{
     dao::{scopes, SearchAssetsQuery},
@@ -14,6 +16,7 @@ pub async fn search_assets(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
+    feature_flags: &HashMap<String, bool>,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -26,6 +29,7 @@ pub async fn search_assets(
         sort_direction,
         &pagination,
         limit,
+        feature_flags,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -18,7 +18,7 @@ pub async fn search_assets(
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
     let (condition, joins) = search_assets_query.conditions()?;
-    let assets = scopes::asset::get_assets_by_condition(
+    let (assets, grand_total) = scopes::asset::get_assets_by_condition(
         db,
         condition,
         joins,
@@ -28,5 +28,11 @@ pub async fn search_assets(
         limit,
     )
     .await?;
-    Ok(build_asset_response(assets, limit, &pagination, &transform))
+    Ok(build_asset_response(
+        assets,
+        limit,
+        grand_total,
+        &pagination,
+        &transform,
+    ))
 }

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use super::common::{build_asset_response, create_pagination, create_sorting};
 use crate::{
     dao::{scopes, SearchAssetsQuery},
@@ -16,7 +14,7 @@ pub async fn search_assets(
     before: Option<Vec<u8>>,
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
-    feature_flags: &HashMap<String, bool>,
+    enable_grand_total_query: bool,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -29,7 +27,7 @@ pub async fn search_assets(
         sort_direction,
         &pagination,
         limit,
-        feature_flags,
+        enable_grand_total_query,
     )
     .await?;
     Ok(build_asset_response(

--- a/digital_asset_types/src/rpc/response.rs
+++ b/digital_asset_types/src/rpc/response.rs
@@ -22,7 +22,7 @@ pub struct GetGroupingResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(default)]
 pub struct AssetList {
-    // pub grand_total: u64, // TODO: add this back in
+    // pub grand_total: u64, // TODO: not adding this for now because we aren't committing to the schema
     pub total: u32,
     pub limit: u32,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/digital_asset_types/src/rpc/response.rs
+++ b/digital_asset_types/src/rpc/response.rs
@@ -22,6 +22,7 @@ pub struct GetGroupingResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(default)]
 pub struct AssetList {
+    pub grand_total: u64,
     pub total: u32,
     pub limit: u32,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/digital_asset_types/src/rpc/response.rs
+++ b/digital_asset_types/src/rpc/response.rs
@@ -22,7 +22,7 @@ pub struct GetGroupingResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(default)]
 pub struct AssetList {
-    pub grand_total: u64,
+    // pub grand_total: u64, // TODO: add this back in
     pub total: u32,
     pub limit: u32,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Overview
- Executes another `COUNT` query to get the total assets matching the query.
- The name for the field is TBD.
- Queries parallelized.
- Feature flag added to toggle this feature on/off via env var.
- The `grand_total` field is disabled from the response fields until we finalize the change.

## Testing
- Testing performed locally to validate the response.
- Testing performed locally with several ~20k leaf trees (max ~60k records) to gauge performance impacts. The impact on response time is negligible.
- More testing is necessary on dev/devnet to measure db load changes, connection usage, tail latency, etc.