### PR TITLE
feat: return `collection_metadata` in grouping info

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -313,7 +313,7 @@ impl ApiContract for DasApi {
             before,
             after,
             json_uri,
-            collection_metadata,
+            show_collection_metadata,
         } = payload;
         // Deserialize search assets query
         self.validate_pagination(&limit, &page, &before, &after)?;
@@ -380,7 +380,8 @@ impl ApiContract for DasApi {
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             &transform,
             self.feature_flags.enable_grand_total_query,
-            self.feature_flags.enable_grouping_metadata && collection_metadata.unwrap_or(false),
+            self.feature_flags.enable_collection_metadata
+                && show_collection_metadata.unwrap_or(false),
         )
         .await
         .map_err(Into::into)

--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -313,6 +313,7 @@ impl ApiContract for DasApi {
             before,
             after,
             json_uri,
+            collection_metadata,
         } = payload;
         // Deserialize search assets query
         self.validate_pagination(&limit, &page, &before, &after)?;
@@ -379,6 +380,7 @@ impl ApiContract for DasApi {
             after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
             &transform,
             self.feature_flags.enable_grand_total_query,
+            self.feature_flags.enable_grouping_metadata && collection_metadata.unwrap_or(false),
         )
         .await
         .map_err(Into::into)

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -89,6 +89,8 @@ pub struct SearchAssets {
     pub after: Option<String>,
     #[serde(default)]
     pub json_uri: Option<String>,
+    #[serde(default)]
+    pub collection_metadata: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -90,7 +90,7 @@ pub struct SearchAssets {
     #[serde(default)]
     pub json_uri: Option<String>,
     #[serde(default)]
-    pub collection_metadata: Option<bool>,
+    pub show_collection_metadata: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/das_api/src/config.rs
+++ b/das_api/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
     pub env: Option<String>,
     pub cdn_prefix: Option<String>,
     pub enable_grand_total_query: Option<bool>,
+    pub enable_grouping_metadata: Option<bool>,
 }
 
 pub fn load_config() -> Result<Config, DasApiError> {

--- a/das_api/src/config.rs
+++ b/das_api/src/config.rs
@@ -13,7 +13,7 @@ pub struct Config {
     pub env: Option<String>,
     pub cdn_prefix: Option<String>,
     pub enable_grand_total_query: Option<bool>,
-    pub enable_grouping_metadata: Option<bool>,
+    pub enable_collection_metadata: Option<bool>,
 }
 
 pub fn load_config() -> Result<Config, DasApiError> {

--- a/das_api/src/feature_flag.rs
+++ b/das_api/src/feature_flag.rs
@@ -2,10 +2,12 @@ use crate::config::Config;
 
 pub struct FeatureFlags {
     pub enable_grand_total_query: bool,
+    pub enable_grouping_metadata: bool,
 }
 
 pub fn get_feature_flags(config: &Config) -> FeatureFlags {
     FeatureFlags {
         enable_grand_total_query: config.enable_grand_total_query.unwrap_or(false),
+        enable_grouping_metadata: config.enable_grouping_metadata.unwrap_or(false),
     }
 }

--- a/das_api/src/feature_flag.rs
+++ b/das_api/src/feature_flag.rs
@@ -2,12 +2,12 @@ use crate::config::Config;
 
 pub struct FeatureFlags {
     pub enable_grand_total_query: bool,
-    pub enable_grouping_metadata: bool,
+    pub enable_collection_metadata: bool,
 }
 
 pub fn get_feature_flags(config: &Config) -> FeatureFlags {
     FeatureFlags {
         enable_grand_total_query: config.enable_grand_total_query.unwrap_or(false),
-        enable_grouping_metadata: config.enable_grouping_metadata.unwrap_or(false),
+        enable_collection_metadata: config.enable_collection_metadata.unwrap_or(false),
     }
 }

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -474,24 +474,30 @@ pub async fn add_collection_metadata(
 }
 
 fn get_collection_metadata(data: &asset_data::Model) -> CollectionMetadata {
-    let mut chain_data_selector_fn = jsonpath_lib::selector(&data.chain_data);
-    let chain_data_selector = &mut chain_data_selector_fn;
+    let chain_data_selector = &mut jsonpath_lib::selector(&data.chain_data);
+    let metadata_selector = &mut jsonpath_lib::selector(&data.metadata);
 
     let name = safe_select(chain_data_selector, "$.name");
     let symbol = safe_select(chain_data_selector, "$.symbol");
+    let image = safe_select(metadata_selector, "$.image");
 
-    let mut metadata_name = "".to_string();
-    let mut metadata_symbol = "".to_string();
+    let mut col_metadata_name = "".to_string();
+    let mut col_metadata_symbol = "".to_string();
+    let mut col_metadata_image = "".to_string();
 
     if let Some(name) = name {
-        metadata_name = name.to_owned().to_string().trim_matches('"').to_string();
+        col_metadata_name = name.to_owned().to_string().trim_matches('"').to_string();
     }
     if let Some(symbol) = symbol {
-        metadata_symbol = symbol.to_owned().to_string().trim_matches('"').to_string();
+        col_metadata_symbol = symbol.to_owned().to_string().trim_matches('"').to_string();
+    }
+    if let Some(image) = image {
+        col_metadata_image = image.to_owned().to_string().trim_matches('"').to_string();
     }
 
     CollectionMetadata {
-        name: Some(metadata_name),
-        symbol: Some(metadata_symbol),
+        name: Some(col_metadata_name),
+        symbol: Some(col_metadata_symbol),
+        image: Some(col_metadata_image),
     }
 }

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -153,7 +153,7 @@ pub fn safe_select<'a>(
         .and_then(|v| v.pop())
 }
 
-fn process_raw_fields(
+pub fn process_raw_fields(
     name: &Option<Vec<u8>>,
     symbol: &Option<Vec<u8>>,
 ) -> (Option<String>, Option<String>) {
@@ -346,6 +346,7 @@ pub fn to_grouping(groups: Vec<asset_grouping::Model>) -> Vec<Group> {
         .map(|a| Group {
             group_key: a.group_key.clone(),
             group_value: a.group_value.clone(),
+            collection_metadata: None,
         })
         .collect()
 }

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -153,7 +153,7 @@ pub fn safe_select<'a>(
         .and_then(|v| v.pop())
 }
 
-pub fn process_raw_fields(
+fn process_raw_fields(
     name: &Option<Vec<u8>>,
     symbol: &Option<Vec<u8>>,
 ) -> (Option<String>, Option<String>) {

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -1,6 +1,9 @@
 use super::common::{build_asset_response, create_pagination, create_sorting};
 use crate::{
-    dao::{scopes, SearchAssetsQuery},
+    dao::{
+        scopes::{self, asset::add_collection_metadata},
+        SearchAssetsQuery,
+    },
     rpc::{filter::AssetSorting, response::AssetList, transform::AssetTransform},
 };
 use sea_orm::{DatabaseConnection, DbErr};
@@ -15,6 +18,7 @@ pub async fn search_assets(
     after: Option<Vec<u8>>,
     transform: &AssetTransform,
     enable_grand_total_query: bool,
+    enable_collection_metadata: bool,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(before, after, page)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
@@ -30,11 +34,9 @@ pub async fn search_assets(
         enable_grand_total_query,
     )
     .await?;
-    Ok(build_asset_response(
-        assets,
-        limit,
-        grand_total,
-        &pagination,
-        &transform,
-    ))
+    let mut asset_list = build_asset_response(assets, limit, grand_total, &pagination, &transform);
+    if enable_collection_metadata {
+        asset_list = add_collection_metadata(db, asset_list).await?;
+    }
+    Ok(asset_list)
 }

--- a/digital_asset_types/src/rpc/asset.rs
+++ b/digital_asset_types/src/rpc/asset.rs
@@ -203,6 +203,14 @@ pub type GroupValue = String;
 pub struct Group {
     pub group_key: String,
     pub group_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collection_metadata: Option<CollectionMetadata>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct CollectionMetadata {
+    pub name: Option<String>,
+    pub symbol: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]

--- a/digital_asset_types/src/rpc/asset.rs
+++ b/digital_asset_types/src/rpc/asset.rs
@@ -211,6 +211,7 @@ pub struct Group {
 pub struct CollectionMetadata {
     pub name: Option<String>,
     pub symbol: Option<String>,
+    pub image: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]


### PR DESCRIPTION
## Overview
- Only when both of the following are enabled, `collection_metadata` is returned:
    - `APP_ENABLE_COLLECTION_METADATA` feature flag
    - the `showCollectionMetadata` field in `searchAssets` method
- Only `searchAssets` method returns collection_metadata for now

## Testing
- Testing done locally to validate changes
