### PR TITLE
feat: secondary Redis streams to handle the backfilling load

### DIFF
--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -22,6 +22,8 @@ pub struct IngesterConfig {
     pub max_postgres_connections: Option<u32>,
     pub account_stream_worker_count: Option<u32>,
     pub transaction_stream_worker_count: Option<u32>,
+    pub account_backfill_stream_worker_count: Option<u32>,
+    pub transaction_backfill_stream_worker_count: Option<u32>,
     pub code_version: Option<&'static str>,
     pub ipfs_gateway: Option<String>,
     pub bg_task_config: Option<BgTaskConfig>,
@@ -50,7 +52,7 @@ impl IngesterConfig {
             .unwrap()
     }
 
-    pub fn get_messneger_client_config(&self) -> MessengerConfig {
+    pub fn get_messenger_client_config(&self) -> MessengerConfig {
         let mut mc = self.messenger_config.clone();
         mc.connection_config
             .insert("consumer_id".to_string(), Value::from(rand_string()));
@@ -63,6 +65,14 @@ impl IngesterConfig {
 
     pub fn get_transaction_stream_worker_count(&self) -> u32 {
         self.transaction_stream_worker_count.unwrap_or(2)
+    }
+
+    pub fn get_acc_backfill_stream_worker_count(&self) -> u32 {
+        self.account_backfill_stream_worker_count.unwrap_or(0)
+    }
+
+    pub fn get_txn_backfill_stream_worker_count(&self) -> u32 {
+        self.transaction_backfill_stream_worker_count.unwrap_or(0)
     }
 }
 

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -68,11 +68,11 @@ impl IngesterConfig {
     }
 
     pub fn get_acc_backfill_stream_worker_count(&self) -> u32 {
-        self.account_backfill_stream_worker_count.unwrap_or(0)
+        self.account_backfill_stream_worker_count.unwrap_or(2)
     }
 
     pub fn get_txn_backfill_stream_worker_count(&self) -> u32 {
-        self.transaction_backfill_stream_worker_count.unwrap_or(0)
+        self.transaction_backfill_stream_worker_count.unwrap_or(2)
     }
 }
 

--- a/nft_ingester/src/database.rs
+++ b/nft_ingester/src/database.rs
@@ -1,10 +1,12 @@
-use sqlx::{postgres::{PgPoolOptions, PgConnectOptions}, PgPool, ConnectOptions};
-
-use crate::{
-    config::{IngesterConfig, IngesterRole},
+use crate::config::{IngesterConfig, IngesterRole};
+use sqlx::{
+    postgres::{PgConnectOptions, PgPoolOptions},
+    ConnectOptions, PgPool,
 };
+
 const BARE_MINIMUM_CONNECTIONS: u32 = 5;
 const DEFAULT_MAX: u32 = 125;
+
 pub async fn setup_database(config: IngesterConfig) -> PgPool {
     let max = config.max_postgres_connections.unwrap_or(DEFAULT_MAX);
     if config.role == Some(IngesterRole::All) || config.role == Some(IngesterRole::Ingester) {
@@ -19,8 +21,11 @@ pub async fn setup_database(config: IngesterConfig) -> PgPool {
     let mut options: PgConnectOptions = url.parse().unwrap();
     options.log_statements(log::LevelFilter::Trace);
 
-    options.log_slow_statements(log::LevelFilter::Info, std::time::Duration::from_millis(500));
-    
+    options.log_slow_statements(
+        log::LevelFilter::Info,
+        std::time::Duration::from_millis(500),
+    );
+
     let pool = PgPoolOptions::new()
         .min_connections(BARE_MINIMUM_CONNECTIONS)
         .max_connections(max)

--- a/nft_ingester/src/stream.rs
+++ b/nft_ingester/src/stream.rs
@@ -1,14 +1,12 @@
-
 use crate::{error::IngesterError, metric};
 use cadence_macros::{is_global_default_set, statsd_count, statsd_gauge};
 
-use log::{error};
+use log::error;
 use plerkle_messenger::{Messenger, MessengerConfig};
 use tokio::{
-    task::{JoinHandle},
+    task::JoinHandle,
     time::{self, Duration},
 };
-
 
 pub struct StreamSizeTimer {
     interval: tokio::time::Duration,
@@ -25,7 +23,7 @@ impl StreamSizeTimer {
         Ok(Self {
             interval: interval_time,
             stream,
-            messenger_config: messenger_config,
+            messenger_config,
         })
     }
 

--- a/nft_ingester/src/transaction_notifications.rs
+++ b/nft_ingester/src/transaction_notifications.rs
@@ -7,7 +7,7 @@ use cadence_macros::{is_global_default_set, statsd_count, statsd_time};
 use chrono::Utc;
 use log::{debug, error};
 use plerkle_messenger::{
-    ConsumptionType, Messenger, MessengerConfig, RecvData, TRANSACTION_STREAM,
+    ConsumptionType, Messenger, MessengerConfig, RecvData, TRANSACTION_STREAM, TXN_BACKFILL,
 };
 use plerkle_serialization::root_as_transaction_info;
 
@@ -24,19 +24,25 @@ pub fn transaction_worker<T: Messenger>(
     bg_task_sender: UnboundedSender<TaskData>,
     ack_channel: UnboundedSender<(&'static str, String)>,
     consumption_type: ConsumptionType,
+    is_backfill_stream: bool,
 ) -> JoinHandle<()> {
+    let stream_key = if is_backfill_stream {
+        TXN_BACKFILL
+    } else {
+        TRANSACTION_STREAM
+    };
     tokio::spawn(async move {
         let source = T::new(config).await;
         if let Ok(mut msg) = source {
             let manager = Arc::new(ProgramTransformer::new(pool, bg_task_sender));
             loop {
-                let e = msg.recv(TRANSACTION_STREAM, consumption_type.clone()).await;
+                let e = msg.recv(stream_key, consumption_type.clone()).await;
                 let mut tasks = JoinSet::new();
                 match e {
                     Ok(data) => {
                         let len = data.len();
                         for item in data {
-                            tasks.spawn(handle_transaction(Arc::clone(&manager), item));
+                            tasks.spawn(handle_transaction(Arc::clone(&manager), item, stream_key));
                         }
                         if len > 0 {
                             debug!("Processed {} txns", len);
@@ -45,18 +51,18 @@ pub fn transaction_worker<T: Messenger>(
                     Err(e) => {
                         error!("Error receiving from txn stream: {}", e);
                         metric! {
-                            statsd_count!("ingester.stream.receive_error", 1, "stream" => TRANSACTION_STREAM);
+                            statsd_count!("ingester.stream.receive_error", 1, "stream" => stream_key);
                         }
                     }
                 }
                 while let Some(res) = tasks.join_next().await {
                     if let Ok(id) = res {
                         if let Some(id) = id {
-                            let send = ack_channel.send((TRANSACTION_STREAM, id));
+                            let send = ack_channel.send((stream_key, id));
                             if let Err(err) = send {
                                 metric! {
                                     error!("Txn stream ack error: {}", err);
-                                    statsd_count!("ingester.stream.ack_error", 1, "stream" => TRANSACTION_STREAM);
+                                    statsd_count!("ingester.stream.ack_error", 1, "stream" => stream_key);
                                 }
                             }
                         }
@@ -67,11 +73,15 @@ pub fn transaction_worker<T: Messenger>(
     })
 }
 
-async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) -> Option<String> {
+async fn handle_transaction(
+    manager: Arc<ProgramTransformer>,
+    item: RecvData,
+    stream_key: &str,
+) -> Option<String> {
     let mut ret_id = None;
     if item.tries > 0 {
         metric! {
-            statsd_count!("ingester.stream_redelivery", 1, "stream" => TRANSACTION_STREAM);
+            statsd_count!("ingester.stream_redelivery", 1, "stream" => stream_key);
         }
     }
     let id = item.id.to_string();
@@ -80,14 +90,14 @@ async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) ->
         let signature = tx.signature().unwrap_or("NO SIG");
         debug!("Received transaction: {}", signature);
         metric! {
-            statsd_count!("ingester.seen", 1, "stream" => TRANSACTION_STREAM);
+            statsd_count!("ingester.seen", 1, "stream" => stream_key);
         }
         let seen_at = Utc::now();
         metric! {
             statsd_time!(
                 "ingester.bus_ingest_time",
                 (seen_at.timestamp_millis() - tx.seen_at()) as u64,
-                "stream" => TRANSACTION_STREAM
+                "stream" => stream_key
             );
         }
 
@@ -95,7 +105,7 @@ async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) ->
         let res = manager.handle_transaction(&tx).await;
         let should_ack = capture_result(
             id.clone(),
-            TRANSACTION_STREAM,
+            stream_key,
             ("txn", "txn"),
             item.tries,
             res,

--- a/tools/acc_forwarder/src/main.rs
+++ b/tools/acc_forwarder/src/main.rs
@@ -80,6 +80,8 @@ impl CollectionTransactionInfo {
     }
 }
 
+const STREAM_KEY: &str = ACCOUNT_STREAM;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env::set_var(
@@ -101,9 +103,9 @@ async fn main() -> anyhow::Result<()> {
     let mut messenger = plerkle_messenger::select_messenger(messenger_config)
         .await
         .unwrap();
-    messenger.add_stream(ACCOUNT_STREAM).await.unwrap();
+    messenger.add_stream(STREAM_KEY).await.unwrap();
     messenger
-        .set_buffer_size(ACCOUNT_STREAM, 10000000000000000)
+        .set_buffer_size(STREAM_KEY, 10000000000000000)
         .await;
     let messenger = Arc::new(Mutex::new(messenger));
 
@@ -420,7 +422,7 @@ async fn send_account(
     let fbb = serialize_account(fbb, &account_info, slot, is_startup);
     let bytes = fbb.finished_data();
 
-    messenger.lock().await.send(ACCOUNT_STREAM, bytes).await?;
+    messenger.lock().await.send(STREAM_KEY, bytes).await?;
     info!("sent account {} to stream", pubkey);
 
     Ok(())


### PR DESCRIPTION
## Overview
-   Two secondary Redis streams added, one for ACC and one for TXN
- The count of these secondary streams is configurable
- The backfiller now uses TXN_BACKFILL stream instead of TRANSACTION_STREAM

## Testing
-   Locally hardcoded the stream_key in acc_forwarder and txn_forwarder to make sure acc/txns are being indexed
