### PR TITLE
feat: make configurable pod type for ingester

### DIFF
--- a/nft_ingester/src/account_updates.rs
+++ b/nft_ingester/src/account_updates.rs
@@ -1,13 +1,16 @@
 use std::sync::Arc;
 
 use crate::{
-    metric, metrics::capture_result, program_transformers::ProgramTransformer, tasks::TaskData,
+    config::PodType, metric, metrics::capture_result, program_transformers::ProgramTransformer,
+    tasks::TaskData,
 };
 use cadence_macros::{is_global_default_set, statsd_count, statsd_time};
 use chrono::Utc;
 
 use log::{debug, error};
-use plerkle_messenger::{ConsumptionType, Messenger, MessengerConfig, RecvData, ACCOUNT_STREAM};
+use plerkle_messenger::{
+    ConsumptionType, Messenger, MessengerConfig, RecvData, ACCOUNT_STREAM, ACC_BACKFILL,
+};
 use plerkle_serialization::root_as_account_info;
 use sqlx::{Pool, Postgres};
 use tokio::{
@@ -22,19 +25,29 @@ pub fn account_worker<T: Messenger>(
     bg_task_sender: UnboundedSender<TaskData>,
     ack_channel: UnboundedSender<(&'static str, String)>,
     consumption_type: ConsumptionType,
+    pod_type: &PodType,
 ) -> JoinHandle<()> {
+    let stream_key: &str;
+    match pod_type {
+        PodType::Backfiller => {
+            stream_key = ACC_BACKFILL;
+        }
+        _ => {
+            stream_key = ACCOUNT_STREAM;
+        }
+    }
     tokio::spawn(async move {
         let source = T::new(config).await;
         if let Ok(mut msg) = source {
             let manager = Arc::new(ProgramTransformer::new(pool, bg_task_sender));
             loop {
-                let e = msg.recv(ACCOUNT_STREAM, consumption_type.clone()).await;
+                let e = msg.recv(stream_key, consumption_type.clone()).await;
                 let mut tasks = JoinSet::new();
                 match e {
                     Ok(data) => {
                         let len = data.len();
                         for item in data {
-                            tasks.spawn(handle_account(Arc::clone(&manager), item));
+                            tasks.spawn(handle_account(Arc::clone(&manager), item, stream_key));
                         }
                         if len > 0 {
                             debug!("Processed {} accounts", len);
@@ -43,18 +56,18 @@ pub fn account_worker<T: Messenger>(
                     Err(e) => {
                         error!("Error receiving from account stream: {}", e);
                         metric! {
-                            statsd_count!("ingester.stream.receive_error", 1, "stream" => ACCOUNT_STREAM);
+                            statsd_count!("ingester.stream.receive_error", 1, "stream" => stream_key);
                         }
                     }
                 }
                 while let Some(res) = tasks.join_next().await {
                     if let Ok(id) = res {
                         if let Some(id) = id {
-                            let send = ack_channel.send((ACCOUNT_STREAM, id));
+                            let send = ack_channel.send((stream_key, id));
                             if let Err(err) = send {
                                 metric! {
                                     error!("Account stream ack error: {}", err);
-                                    statsd_count!("ingester.stream.ack_error", 1, "stream" => ACCOUNT_STREAM);
+                                    statsd_count!("ingester.stream.ack_error", 1, "stream" => stream_key);
                                 }
                             }
                         }
@@ -65,7 +78,11 @@ pub fn account_worker<T: Messenger>(
     })
 }
 
-async fn handle_account(manager: Arc<ProgramTransformer>, item: RecvData) -> Option<String> {
+async fn handle_account(
+    manager: Arc<ProgramTransformer>,
+    item: RecvData,
+    stream_key: &str,
+) -> Option<String> {
     let id = item.id;
     let mut ret_id = None;
     let data = item.data;
@@ -79,13 +96,13 @@ async fn handle_account(manager: Arc<ProgramTransformer>, item: RecvData) -> Opt
         let str_program_id =
             bs58::encode(account_update.owner().unwrap().0.as_slice()).into_string();
         metric! {
-            statsd_count!("ingester.seen", 1, "owner" => &str_program_id, "stream" => ACCOUNT_STREAM);
+            statsd_count!("ingester.seen", 1, "owner" => &str_program_id, "stream" => stream_key);
             let seen_at = Utc::now();
             statsd_time!(
                 "ingester.bus_ingest_time",
                 (seen_at.timestamp_millis() - account_update.seen_at()) as u64,
                 "owner" => &str_program_id,
-                "stream" => ACCOUNT_STREAM
+                "stream" => stream_key
             );
         }
         let mut account = None;
@@ -96,7 +113,7 @@ async fn handle_account(manager: Arc<ProgramTransformer>, item: RecvData) -> Opt
         let res = manager.handle_account_update(account_update).await;
         let should_ack = capture_result(
             id.clone(),
-            ACCOUNT_STREAM,
+            stream_key,
             ("owner", &str_program_id),
             item.tries,
             res,

--- a/nft_ingester/src/account_updates.rs
+++ b/nft_ingester/src/account_updates.rs
@@ -27,15 +27,10 @@ pub fn account_worker<T: Messenger>(
     consumption_type: ConsumptionType,
     pod_type: &PodType,
 ) -> JoinHandle<()> {
-    let stream_key: &str;
-    match pod_type {
-        PodType::Backfiller => {
-            stream_key = ACC_BACKFILL;
-        }
-        _ => {
-            stream_key = ACCOUNT_STREAM;
-        }
-    }
+    let stream_key = match pod_type {
+        PodType::Backfiller => ACC_BACKFILL,
+        PodType::Regular => ACCOUNT_STREAM,
+    };
     tokio::spawn(async move {
         let source = T::new(config).await;
         if let Ok(mut msg) = source {

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -25,6 +25,7 @@ pub struct IngesterConfig {
     pub code_version: Option<&'static str>,
     pub ipfs_gateway: Option<String>,
     pub bg_task_config: Option<BgTaskConfig>,
+    pub pod_type: Option<PodType>,
 }
 
 impl IngesterConfig {
@@ -93,6 +94,21 @@ impl Display for IngesterRole {
             IngesterRole::Backfiller => write!(f, "Backfiller"),
             IngesterRole::BackgroundTaskRunner => write!(f, "BackgroundTaskRunner"),
             IngesterRole::Ingester => write!(f, "Ingester"),
+        }
+    }
+}
+
+#[derive(Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum PodType {
+    Regular,
+    Backfiller,
+}
+
+impl Display for PodType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PodType::Regular => write!(f, "Regular"),
+            PodType::Backfiller => write!(f, "Backfiller"),
         }
     }
 }

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -49,6 +49,7 @@ pub async fn main() -> Result<(), IngesterError> {
     info!("Starting Program with Role {}", role);
     //The pod_type determines the type of pod the ingester is running in
     let pod_type = config.clone().pod_type.unwrap_or(PodType::Regular);
+    info!("Starting Program with Pod Type {}", pod_type);
     // Tasks Setup -----------------------------------------------
     // This joinSet manages all the tasks that are spawned.
     let mut tasks = JoinSet::new();

--- a/nft_ingester/src/stream.rs
+++ b/nft_ingester/src/stream.rs
@@ -1,14 +1,12 @@
-
 use crate::{error::IngesterError, metric};
 use cadence_macros::{is_global_default_set, statsd_count, statsd_gauge};
 
-use log::{error};
+use log::error;
 use plerkle_messenger::{Messenger, MessengerConfig};
 use tokio::{
-    task::{JoinHandle},
+    task::JoinHandle,
     time::{self, Duration},
 };
-
 
 pub struct StreamSizeTimer {
     interval: tokio::time::Duration,

--- a/nft_ingester/src/transaction_notifications.rs
+++ b/nft_ingester/src/transaction_notifications.rs
@@ -8,7 +8,7 @@ use cadence_macros::{is_global_default_set, statsd_count, statsd_time};
 use chrono::Utc;
 use log::{debug, error};
 use plerkle_messenger::{
-    ConsumptionType, Messenger, MessengerConfig, RecvData, TRANSACTION_STREAM, TXN_BACKFILL,
+    ConsumptionType, Messenger, MessengerConfig, RecvData, TRANSACTION_STREAM,
 };
 use plerkle_serialization::root_as_transaction_info;
 
@@ -27,10 +27,7 @@ pub fn transaction_worker<T: Messenger>(
     consumption_type: ConsumptionType,
     pod_type: &PodType,
 ) -> JoinHandle<()> {
-    let stream_key = match pod_type {
-        PodType::Backfiller => TXN_BACKFILL,
-        PodType::Regular => TRANSACTION_STREAM,
-    };
+    let stream_key = TRANSACTION_STREAM; // TODO: send txns to TXN_BACKFILL stream on full flush (from plugin)
     tokio::spawn(async move {
         let source = T::new(config).await;
         if let Ok(mut msg) = source {

--- a/nft_ingester/src/transaction_notifications.rs
+++ b/nft_ingester/src/transaction_notifications.rs
@@ -27,15 +27,10 @@ pub fn transaction_worker<T: Messenger>(
     consumption_type: ConsumptionType,
     pod_type: &PodType,
 ) -> JoinHandle<()> {
-    let stream_key: &str;
-    match pod_type {
-        PodType::Backfiller => {
-            stream_key = TXN_BACKFILL;
-        }
-        _ => {
-            stream_key = TRANSACTION_STREAM;
-        }
-    }
+    let stream_key = match pod_type {
+        PodType::Backfiller => TXN_BACKFILL,
+        PodType::Regular => TRANSACTION_STREAM,
+    };
     tokio::spawn(async move {
         let source = T::new(config).await;
         if let Ok(mut msg) = source {

--- a/nft_ingester/src/transaction_notifications.rs
+++ b/nft_ingester/src/transaction_notifications.rs
@@ -1,13 +1,14 @@
 use std::sync::Arc;
 
 use crate::{
-    metric, metrics::capture_result, program_transformers::ProgramTransformer, tasks::TaskData,
+    config::PodType, metric, metrics::capture_result, program_transformers::ProgramTransformer,
+    tasks::TaskData,
 };
 use cadence_macros::{is_global_default_set, statsd_count, statsd_time};
 use chrono::Utc;
 use log::{debug, error};
 use plerkle_messenger::{
-    ConsumptionType, Messenger, MessengerConfig, RecvData, TRANSACTION_STREAM,
+    ConsumptionType, Messenger, MessengerConfig, RecvData, TRANSACTION_STREAM, TXN_BACKFILL,
 };
 use plerkle_serialization::root_as_transaction_info;
 
@@ -24,19 +25,29 @@ pub fn transaction_worker<T: Messenger>(
     bg_task_sender: UnboundedSender<TaskData>,
     ack_channel: UnboundedSender<(&'static str, String)>,
     consumption_type: ConsumptionType,
+    pod_type: &PodType,
 ) -> JoinHandle<()> {
+    let stream_key: &str;
+    match pod_type {
+        PodType::Backfiller => {
+            stream_key = TXN_BACKFILL;
+        }
+        _ => {
+            stream_key = TRANSACTION_STREAM;
+        }
+    }
     tokio::spawn(async move {
         let source = T::new(config).await;
         if let Ok(mut msg) = source {
             let manager = Arc::new(ProgramTransformer::new(pool, bg_task_sender));
             loop {
-                let e = msg.recv(TRANSACTION_STREAM, consumption_type.clone()).await;
+                let e = msg.recv(stream_key, consumption_type.clone()).await;
                 let mut tasks = JoinSet::new();
                 match e {
                     Ok(data) => {
                         let len = data.len();
                         for item in data {
-                            tasks.spawn(handle_transaction(Arc::clone(&manager), item));
+                            tasks.spawn(handle_transaction(Arc::clone(&manager), item, stream_key));
                         }
                         if len > 0 {
                             debug!("Processed {} txns", len);
@@ -45,18 +56,18 @@ pub fn transaction_worker<T: Messenger>(
                     Err(e) => {
                         error!("Error receiving from txn stream: {}", e);
                         metric! {
-                            statsd_count!("ingester.stream.receive_error", 1, "stream" => TRANSACTION_STREAM);
+                            statsd_count!("ingester.stream.receive_error", 1, "stream" => stream_key);
                         }
                     }
                 }
                 while let Some(res) = tasks.join_next().await {
                     if let Ok(id) = res {
                         if let Some(id) = id {
-                            let send = ack_channel.send((TRANSACTION_STREAM, id));
+                            let send = ack_channel.send((stream_key, id));
                             if let Err(err) = send {
                                 metric! {
                                     error!("Txn stream ack error: {}", err);
-                                    statsd_count!("ingester.stream.ack_error", 1, "stream" => TRANSACTION_STREAM);
+                                    statsd_count!("ingester.stream.ack_error", 1, "stream" => stream_key);
                                 }
                             }
                         }
@@ -67,11 +78,15 @@ pub fn transaction_worker<T: Messenger>(
     })
 }
 
-async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) -> Option<String> {
+async fn handle_transaction(
+    manager: Arc<ProgramTransformer>,
+    item: RecvData,
+    stream_key: &str,
+) -> Option<String> {
     let mut ret_id = None;
     if item.tries > 0 {
         metric! {
-            statsd_count!("ingester.stream_redelivery", 1, "stream" => TRANSACTION_STREAM);
+            statsd_count!("ingester.stream_redelivery", 1, "stream" => stream_key);
         }
     }
     let id = item.id.to_string();
@@ -80,14 +95,14 @@ async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) ->
         let signature = tx.signature().unwrap_or("NO SIG");
         debug!("Received transaction: {}", signature);
         metric! {
-            statsd_count!("ingester.seen", 1, "stream" => TRANSACTION_STREAM);
+            statsd_count!("ingester.seen", 1, "stream" => stream_key);
         }
         let seen_at = Utc::now();
         metric! {
             statsd_time!(
                 "ingester.bus_ingest_time",
                 (seen_at.timestamp_millis() - tx.seen_at()) as u64,
-                "stream" => TRANSACTION_STREAM
+                "stream" => stream_key
             );
         }
 
@@ -95,7 +110,7 @@ async fn handle_transaction(manager: Arc<ProgramTransformer>, item: RecvData) ->
         let res = manager.handle_transaction(&tx).await;
         let should_ack = capture_result(
             id.clone(),
-            TRANSACTION_STREAM,
+            stream_key,
             ("txn", "txn"),
             item.tries,
             res,


### PR DESCRIPTION
## Overview
- Make a configurable `pod_type` via env var which dictates which messenger stream will be used  

## Testing
-   Testing performed locally to validate the changes
