### PR TITLE
`searchAssets`: add raw name + owner address query parameter support

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -22,7 +22,7 @@ use sea_orm::{sea_query::ConditionType, ConnectionTrait, DbBackend, Statement};
 
 use crate::{
     feature_flag::{get_feature_flags, FeatureFlags},
-    validation::validate_opt_pubkey,
+    validation::{validate_opt_pubkey, validate_search_with_name},
 };
 use open_rpc_schema::document::OpenrpcDocument;
 use {
@@ -358,6 +358,7 @@ impl ApiContract for DasApi {
             after,
             json_uri,
             show_collection_metadata,
+            name,
         } = payload;
         // Deserialize search assets query
         self.validate_pagination(&limit, &page, &before, &after)?;
@@ -370,6 +371,7 @@ impl ApiContract for DasApi {
             SearchConditionType::All => ConditionType::All,
         });
         let owner_address = validate_opt_pubkey(&owner_address)?;
+        let name = validate_search_with_name(&name, &owner_address)?;
         let creator_address = validate_opt_pubkey(&creator_address)?;
         let delegate = validate_opt_pubkey(&delegate)?;
 
@@ -408,6 +410,7 @@ impl ApiContract for DasApi {
             royalty_amount,
             burnt,
             json_uri,
+            name,
         };
         let sort_by = sort_by.unwrap_or_default();
         let transform = AssetTransform {

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -91,6 +91,7 @@ pub struct SearchAssets {
     pub json_uri: Option<String>,
     #[serde(default)]
     pub show_collection_metadata: Option<bool>,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/das_api/src/validation.rs
+++ b/das_api/src/validation.rs
@@ -6,6 +6,23 @@ pub fn validate_pubkey(str_pubkey: String) -> Result<Pubkey, DasApiError> {
     Pubkey::from_str(&str_pubkey).map_err(|_| DasApiError::PubkeyValidationError(str_pubkey))
 }
 
+pub fn validate_search_with_name(
+    name: &Option<String>,
+    owner: &Option<Vec<u8>>,
+) -> Result<Option<Vec<u8>>, DasApiError> {
+    let opt_name = if let Some(n) = name {
+        if owner.is_none() {
+            return Err(DasApiError::ValidationError(
+                "Owner address must be provided in order to search assets by name".to_owned(),
+            ));
+        }
+        Some(n.clone().into_bytes())
+    } else {
+        None
+    };
+    Ok(opt_name)
+}
+
 pub fn validate_opt_pubkey(pubkey: &Option<String>) -> Result<Option<Vec<u8>>, DasApiError> {
     let opt_bytes = if let Some(pubkey) = pubkey {
         let pubkey = Pubkey::from_str(pubkey)

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -256,7 +256,8 @@ impl SearchAssetsQuery {
                 )
             })?;
 
-            let cond = Condition::all().add(asset_data::Column::RawName.like(name_as_str));
+            let name_expr = SimpleExpr::Custom(format!("chain_data->>'name' LIKE '%{}%'", name_as_str).into());
+            conditions = conditions.add(name_expr);
             conditions = conditions.add(cond);
             let rel = asset_data::Relation::Asset
                 .def()

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -250,7 +250,13 @@ impl SearchAssetsQuery {
         }
 
         if let Some(n) = self.name.to_owned() {
-            let cond = Condition::all().add(asset_data::Column::RawName.eq(n));
+            let name_as_str = std::str::from_utf8(&n).map_err(|_| {
+                DbErr::Custom(
+                    "Could not convert raw name bytes into string for comparison".to_owned(),
+                )
+            })?;
+
+            let cond = Condition::all().add(asset_data::Column::RawName.like(name_as_str));
             conditions = conditions.add(cond);
             let rel = asset_data::Relation::Asset
                 .def()

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -11,7 +11,7 @@ use self::sea_orm_active_enums::{
 use sea_orm::{
     entity::*,
     sea_query::Expr,
-    sea_query::{ConditionType, IntoCondition},
+    sea_query::{ConditionType, IntoCondition, SimpleExpr},
     Condition, DbErr, RelationDef,
 };
 
@@ -256,9 +256,9 @@ impl SearchAssetsQuery {
                 )
             })?;
 
-            let name_expr = SimpleExpr::Custom(format!("chain_data->>'name' LIKE '%{}%'", name_as_str).into());
+            let name_expr =
+                SimpleExpr::Custom(format!("chain_data->>'name' LIKE '%{}%'", name_as_str).into());
             conditions = conditions.add(name_expr);
-            conditions = conditions.add(cond);
             let rel = asset_data::Relation::Asset
                 .def()
                 .rev()

--- a/digital_asset_types/tests/common.rs
+++ b/digital_asset_types/tests/common.rs
@@ -231,7 +231,7 @@ pub fn create_asset_grouping(
             id: row_num,
             group_key: "collection".to_string(),
             slot_updated: Some(0),
-            verified: false,
+            verified: Some(false),
             group_info_seq: Some(0),
         },
     )


### PR DESCRIPTION
## Overview

Adds an optional new `name` query parameter to the `searchAssets` method. This parameter _must_ be used in conjunction with an owner address filter and adds a new condition and relational join for a _partial_ match on assets' `RawName` data column.

## Testing

-   Testing performed to validate the changes
