### PR TITLE
feat: displayOptions + batch endpoints + keyset pagination + token_standard

### DIFF
--- a/das_api/src/builder.rs
+++ b/das_api/src/builder.rs
@@ -22,11 +22,32 @@ impl RpcApiBuilder {
         })?;
         module.register_alias("getAssetProof", "get_asset_proof")?;
 
+        module.register_async_method(
+            "get_asset_proof_batch",
+            |rpc_params, rpc_context| async move {
+                let payload = rpc_params.parse::<GetAssetProofBatch>()?;
+                rpc_context
+                    .get_asset_proof_batch(payload)
+                    .await
+                    .map_err(Into::into)
+            },
+        )?;
+        module.register_alias("getAssetProofBatch", "get_asset_proof_batch")?;
+
         module.register_async_method("get_asset", |rpc_params, rpc_context| async move {
             let payload = rpc_params.parse::<GetAsset>()?;
             rpc_context.get_asset(payload).await.map_err(Into::into)
         })?;
         module.register_alias("getAsset", "get_asset")?;
+
+        module.register_async_method("get_asset_batch", |rpc_params, rpc_context| async move {
+            let payload = rpc_params.parse::<GetAssetBatch>()?;
+            rpc_context
+                .get_asset_batch(payload)
+                .await
+                .map_err(Into::into)
+        })?;
+        module.register_alias("getAssetBatch", "get_asset_batch")?;
 
         module.register_async_method(
             "get_assets_by_owner",

--- a/das_api/src/error.rs
+++ b/das_api/src/error.rs
@@ -22,6 +22,16 @@ pub enum DasApiError {
     PaginationEmptyError,
     #[error("Deserialization error: {0}")]
     DeserializationError(#[from] serde_json::Error),
+    #[error("Paginating beyond 500000 items is temporarily disabled. Please contact Helius support for more details.")]
+    OffsetLimitExceededError,
+    #[error("Pagination Error. Limit should not be greater than 1000.")]
+    PaginationExceededError,
+    #[error("Batch Size Error. Batch size should not be greater than 1000.")]
+    BatchSizeExceededError,
+    #[error("Pagination Sorting Error. Only sorting based on id is support for this pagination")]
+    PaginationSortingValidationError,
+    #[error("Cursor Validation Err: {0} is invalid")]
+    CursorValidationError(String),
 }
 
 impl Into<RpcError> for DasApiError {

--- a/das_api/src/feature_flag.rs
+++ b/das_api/src/feature_flag.rs
@@ -1,13 +1,10 @@
-use crate::config::Config;
+use digital_asset_types::feature_flag::FeatureFlags;
 
-pub struct FeatureFlags {
-    pub enable_grand_total_query: bool,
-    pub enable_collection_metadata: bool,
-}
+use crate::config::Config;
 
 pub fn get_feature_flags(config: &Config) -> FeatureFlags {
     FeatureFlags {
-        enable_grand_total_query: config.enable_grand_total_query.unwrap_or(false),
-        enable_collection_metadata: config.enable_collection_metadata.unwrap_or(false),
+        enable_grand_total_query: config.enable_grand_total_query.unwrap_or(true),
+        enable_collection_metadata: config.enable_collection_metadata.unwrap_or(true),
     }
 }

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -272,8 +272,10 @@ impl SearchAssetsQuery {
                 )
             })?;
 
-            let name_expr =
-                SimpleExpr::Custom(format!("chain_data->>'name' LIKE '%{}%'", name_as_str).into());
+            let name_expr = SimpleExpr::Custom(
+                format!("encode(raw_name, 'escape') LIKE '%%{}%%'", name_as_str).into(),
+            );
+
             conditions = conditions.add(name_expr);
             let rel = asset_data::Relation::Asset
                 .def()

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -272,9 +272,8 @@ impl SearchAssetsQuery {
                 )
             })?;
 
-            let name_expr = SimpleExpr::Custom(
-                format!("encode(raw_name, 'escape') LIKE '%%{}%%'", name_as_str).into(),
-            );
+            let name_expr =
+                SimpleExpr::Custom(format!("chain_data->>'name' LIKE '%{}%'", name_as_str).into());
 
             conditions = conditions.add(name_expr);
             let rel = asset_data::Relation::Asset

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -4,6 +4,7 @@ pub mod scopes;
 pub use full_asset::*;
 #[allow(ambiguous_glob_reexports)]
 pub use generated::*;
+use serde::{Deserialize, Serialize};
 
 use self::sea_orm_active_enums::{
     OwnerType, RoyaltyTargetType, SpecificationAssetClass, SpecificationVersions,
@@ -19,6 +20,20 @@ pub struct GroupingSize {
     pub size: u64,
 }
 
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct PageOptions {
+    pub limit: u64,
+    pub page: Option<u64>,
+    pub before: Option<Vec<u8>>,
+    pub after: Option<Vec<u8>>,
+    pub cursor: Option<Cursor>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct Cursor {
+    pub id: Option<Vec<u8>>,
+}
+
 pub enum Pagination {
     Keyset {
         before: Option<Vec<u8>>,
@@ -27,6 +42,7 @@ pub enum Pagination {
     Page {
         page: u64,
     },
+    Cursor(Cursor),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -114,11 +114,15 @@ pub async fn get_by_grouping(
     enable_grand_total_query: bool,
     show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr> {
-    let expr = asset_grouping::Column::GroupValue.eq(group_value).and(
-        asset_grouping::Column::Verified
-            .eq(true)
-            .or(asset_grouping::Column::Verified.is_null()),
-    );
+    let mut expr = asset_grouping::Column::GroupValue.eq(group_value);
+    if !show_unverified_collections {
+        expr = expr.and(
+            asset_grouping::Column::Verified
+                .eq(true)
+                .or(asset_grouping::Column::Verified.is_null()),
+        );
+    }
+
     let condition = Condition::all().add(expr);
     get_assets_by_condition(
         conn,

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -1,11 +1,11 @@
 use crate::{
     dao::{
         asset::{self, Entity},
-        asset_authority, asset_creators, asset_data, asset_grouping, cl_audits, FullAsset,
+        asset_authority, asset_creators, asset_data, asset_grouping, cl_audits, Cursor, FullAsset,
         GroupingSize, Pagination,
     },
     dapi::common::safe_select,
-    rpc::{response::AssetList, CollectionMetadata},
+    rpc::{display_options::DisplayOptions, Asset, CollectionMetadata},
 };
 
 use indexmap::IndexMap;
@@ -13,23 +13,39 @@ use sea_orm::{entity::*, query::*, ConnectionTrait, DbErr, Order};
 use std::collections::{HashMap, HashSet};
 use tokio::try_join;
 
-pub fn paginate<'db, T>(pagination: &Pagination, limit: u64, stmt: T) -> T
+pub fn paginate<'db, T, C>(
+    pagination: &Pagination,
+    limit: u64,
+    stmt: T,
+    sort_direction: Order,
+    column: C,
+) -> T
 where
     T: QueryFilter + QuerySelect,
+    C: ColumnTrait,
 {
     let mut stmt = stmt;
     match pagination {
         Pagination::Keyset { before, after } => {
             if let Some(b) = before {
-                stmt = stmt.filter(asset::Column::Id.lt(b.clone()));
+                stmt = stmt.filter(column.lt(b.clone()));
             }
             if let Some(a) = after {
-                stmt = stmt.filter(asset::Column::Id.gt(a.clone()));
+                stmt = stmt.filter(column.gt(a.clone()));
             }
         }
         Pagination::Page { page } => {
             if *page > 0 {
                 stmt = stmt.offset((page - 1) * limit)
+            }
+        }
+        Pagination::Cursor(cursor) => {
+            if *cursor != Cursor::default() {
+                if sort_direction == sea_orm::Order::Asc {
+                    stmt = stmt.filter(column.gt(cursor.id.clone()));
+                } else {
+                    stmt = stmt.filter(column.lt(cursor.id.clone()));
+                }
             }
         }
     }
@@ -45,6 +61,7 @@ pub async fn get_by_creator(
     pagination: &Pagination,
     limit: u64,
     enable_grand_total_query: bool,
+    show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr> {
     let mut condition = Condition::all()
         .add(asset_creators::Column::Creator.eq(creator))
@@ -61,6 +78,7 @@ pub async fn get_by_creator(
         pagination,
         limit,
         enable_grand_total_query,
+        show_unverified_collections,
     )
     .await
 }
@@ -88,33 +106,30 @@ pub async fn get_grouping(
 
 pub async fn get_by_grouping(
     conn: &impl ConnectionTrait,
-    group_key: String,
     group_value: String,
     sort_by: Option<asset::Column>,
     sort_direction: Order,
     pagination: &Pagination,
     limit: u64,
     enable_grand_total_query: bool,
+    show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr> {
-    let condition = asset_grouping::Column::GroupKey
-        .eq(group_key)
-        .and(asset_grouping::Column::GroupValue.eq(group_value))
-        .and(
-            asset_grouping::Column::Verified
-                .eq(true)
-                .or(asset_grouping::Column::Verified.is_null()),
-        );
-    get_by_related_condition(
+    let expr = asset_grouping::Column::GroupValue.eq(group_value).and(
+        asset_grouping::Column::Verified
+            .eq(true)
+            .or(asset_grouping::Column::Verified.is_null()),
+    );
+    let condition = Condition::all().add(expr);
+    get_assets_by_condition(
         conn,
-        Condition::all()
-            .add(condition)
-            .add(asset::Column::Supply.gt(0)),
-        asset::Relation::AssetGrouping,
+        condition,
+        vec![],
         sort_by,
         sort_direction,
         pagination,
         limit,
         enable_grand_total_query,
+        show_unverified_collections,
     )
     .await
 }
@@ -127,6 +142,7 @@ pub async fn get_assets_by_owner(
     pagination: &Pagination,
     limit: u64,
     enable_grand_total_query: bool,
+    show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr> {
     let cond = Condition::all()
         .add(asset::Column::Owner.eq(owner))
@@ -140,8 +156,34 @@ pub async fn get_assets_by_owner(
         pagination,
         limit,
         enable_grand_total_query,
+        show_unverified_collections,
     )
     .await
+}
+
+pub async fn get_asset_batch(
+    conn: &impl ConnectionTrait,
+    asset_ids: Vec<Vec<u8>>,
+    pagination: &Pagination,
+    limit: u64,
+) -> Result<Vec<FullAsset>, DbErr> {
+    let cond = Condition::all()
+        .add(asset::Column::Id.is_in(asset_ids))
+        .add(asset::Column::Supply.gt(0));
+    let (assets, _grand_total) = get_assets_by_condition(
+        conn,
+        cond,
+        vec![],
+        // Default values provided. The args below are not used for batch requests
+        None,
+        Order::Asc,
+        pagination,
+        limit,
+        false,
+        false,
+    )
+    .await?;
+    Ok(assets)
 }
 
 pub async fn get_by_authority(
@@ -152,41 +194,23 @@ pub async fn get_by_authority(
     pagination: &Pagination,
     limit: u64,
     enable_grand_total_query: bool,
+    show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr> {
     let cond = Condition::all()
         .add(asset_authority::Column::Authority.eq(authority))
         .add(asset::Column::Supply.gt(0));
-    get_by_related_condition(
+    get_assets_by_condition(
         conn,
         cond,
-        asset::Relation::AssetAuthority,
+        vec![],
         sort_by,
         sort_direction,
         pagination,
         limit,
         enable_grand_total_query,
+        show_unverified_collections,
     )
     .await
-}
-
-async fn get_by_related_condition_unsorted<E>(
-    conn: &impl ConnectionTrait,
-    condition: Condition,
-    relation: E,
-    pagination: &Pagination,
-    limit: u64,
-    enable_grand_total_query: bool,
-) -> Result<(Vec<FullAsset>, Option<u64>), DbErr>
-where
-    E: RelationTrait,
-{
-    let stmt = asset::Entity::find()
-        .filter(condition)
-        .join(JoinType::LeftJoin, relation.def());
-
-    let (assets, grand_total) =
-        get_full_response(conn, stmt, pagination, limit, enable_grand_total_query).await?;
-    Ok((assets, grand_total))
 }
 
 async fn get_by_related_condition<E>(
@@ -198,6 +222,7 @@ async fn get_by_related_condition<E>(
     pagination: &Pagination,
     limit: u64,
     enable_grand_total_query: bool,
+    show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr>
 where
     E: RelationTrait,
@@ -209,17 +234,27 @@ where
     if let Some(col) = sort_by {
         stmt = stmt
             .order_by(col, sort_direction.clone())
-            .order_by(asset::Column::Id, sort_direction);
+            .order_by(asset::Column::Id, sort_direction.clone());
     }
 
-    let (assets, grand_total) =
-        get_full_response(conn, stmt, pagination, limit, enable_grand_total_query).await?;
+    let (assets, grand_total) = get_full_response(
+        conn,
+        stmt,
+        pagination,
+        limit,
+        sort_by,
+        sort_direction,
+        enable_grand_total_query,
+        show_unverified_collections,
+    )
+    .await?;
     Ok((assets, grand_total))
 }
 
 pub async fn get_related_for_assets(
     conn: &impl ConnectionTrait,
     assets: Vec<asset::Model>,
+    show_unverified_collections: bool,
 ) -> Result<Vec<FullAsset>, DbErr> {
     let asset_ids = assets.iter().map(|a| a.id.clone()).collect::<Vec<_>>();
 
@@ -275,16 +310,20 @@ pub async fn get_related_for_assets(
         }
     }
 
+    let cond = if show_unverified_collections {
+        Condition::all()
+    } else {
+        Condition::any()
+            .add(asset_grouping::Column::Verified.eq(true))
+            // Older versions of the indexer did not have the verified flag. A group would be present if and only if it was verified.
+            // Therefore if verified is null, we can assume that the group is verified.
+            .add(asset_grouping::Column::Verified.is_null())
+    };
+
     let grouping = asset_grouping::Entity::find()
         .filter(asset_grouping::Column::AssetId.is_in(ids.clone()))
         .filter(asset_grouping::Column::GroupValue.is_not_null())
-        .filter(
-            Condition::any()
-                .add(asset_grouping::Column::Verified.eq(true))
-                // Older versions of the indexer did not have the verified flag. A group would be present if and only if it was verified.
-                // Therefore if verified is null, we can assume that the group is verified.
-                .add(asset_grouping::Column::Verified.is_null()),
-        )
+        .filter(cond)
         .order_by_asc(asset_grouping::Column::AssetId)
         .all(conn)
         .await?;
@@ -306,6 +345,7 @@ pub async fn get_assets_by_condition(
     pagination: &Pagination,
     limit: u64,
     enable_grand_total_query: bool,
+    show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr> {
     let mut stmt = asset::Entity::find();
     for def in joins {
@@ -315,11 +355,20 @@ pub async fn get_assets_by_condition(
     if let Some(col) = sort_by {
         stmt = stmt
             .order_by(col, sort_direction.clone())
-            .order_by(asset::Column::Id, sort_direction);
+            .order_by(asset::Column::Id, sort_direction.clone());
     }
 
-    let (assets, grand_total) =
-        get_full_response(conn, stmt, pagination, limit, enable_grand_total_query).await?;
+    let (assets, grand_total) = get_full_response(
+        conn,
+        stmt,
+        pagination,
+        limit,
+        sort_by,
+        sort_direction,
+        enable_grand_total_query,
+        show_unverified_collections,
+    )
+    .await?;
     Ok((assets, grand_total))
 }
 
@@ -327,6 +376,7 @@ pub async fn get_by_id(
     conn: &impl ConnectionTrait,
     asset_id: Vec<u8>,
     include_no_supply: bool,
+    display_options: &DisplayOptions,
 ) -> Result<FullAsset, DbErr> {
     let mut asset_data =
         asset::Entity::find_by_id(asset_id.clone()).find_also_related(asset_data::Entity);
@@ -350,16 +400,19 @@ pub async fn get_by_id(
         .order_by_asc(asset_creators::Column::Position)
         .all(conn)
         .await?;
+    let cond = if display_options.show_unverified_collections {
+        Condition::all()
+    } else {
+        Condition::any()
+            .add(asset_grouping::Column::Verified.eq(true))
+            // Older versions of the indexer did not have the verified flag. A group would be present if and only if it was verified.
+            // Therefore if verified is null, we can assume that the group is verified.
+            .add(asset_grouping::Column::Verified.is_null())
+    };
     let grouping: Vec<asset_grouping::Model> = asset_grouping::Entity::find()
         .filter(asset_grouping::Column::AssetId.eq(asset.id.clone()))
         .filter(asset_grouping::Column::GroupValue.is_not_null())
-        .filter(
-            Condition::any()
-                .add(asset_grouping::Column::Verified.eq(true))
-                // Older versions of the indexer did not have the verified flag. A group would be present if and only if it was verified.
-                // Therefore if verified is null, we can assume that the group is verified.
-                .add(asset_grouping::Column::Verified.is_null()),
-        )
+        .filter(cond)
         .order_by_asc(asset_grouping::Column::AssetId)
         .all(conn)
         .await?;
@@ -378,16 +431,22 @@ pub async fn fetch_transactions(
     leaf_id: i64,
     pagination: &Pagination,
     limit: u64,
-) -> Result<Vec<Vec<String>>, DbErr> {
+) -> Result<Vec<(String, String)>, DbErr> {
     let mut stmt = cl_audits::Entity::find().filter(cl_audits::Column::Tree.eq(tree));
     stmt = stmt.filter(cl_audits::Column::LeafIdx.eq(leaf_id));
     stmt = stmt.order_by(cl_audits::Column::CreatedAt, sea_orm::Order::Desc);
 
-    stmt = paginate(pagination, limit, stmt);
+    stmt = paginate(
+        pagination,
+        limit,
+        stmt,
+        sea_orm::Order::Asc,
+        asset::Column::Id,
+    );
     let transactions = stmt.all(conn).await?;
-    let transaction_list: Vec<Vec<String>> = transactions
+    let transaction_list: Vec<(String, String)> = transactions
         .into_iter()
-        .map(|transaction| vec![transaction.tx, transaction.instruction])
+        .map(|transaction| (transaction.tx, transaction.instruction))
         .collect();
 
     Ok(transaction_list)
@@ -400,7 +459,7 @@ pub async fn get_signatures_for_asset(
     leaf_idx: Option<i64>,
     pagination: &Pagination,
     limit: u64,
-) -> Result<Vec<Vec<String>>, DbErr> {
+) -> Result<Vec<(String, String)>, DbErr> {
     // if tree_id and leaf_idx are provided, use them directly to fetch transactions
     if let (Some(tree_id), Some(leaf_idx)) = (tree_id, leaf_idx) {
         let transactions = fetch_transactions(conn, tree_id, leaf_idx, pagination, limit).await?;
@@ -443,18 +502,24 @@ async fn get_full_response(
     stmt: Select<Entity>,
     pagination: &Pagination,
     limit: u64,
+    _sort_by: Option<asset::Column>,
+    sort_direction: Order,
     enable_grand_total_query: bool,
+    show_unverified_collections: bool,
 ) -> Result<(Vec<FullAsset>, Option<u64>), DbErr> {
     if enable_grand_total_query {
         let grand_total_task = get_grand_total(conn, stmt.clone());
-        let assets_task = paginate(pagination, limit, stmt).all(conn);
+        let assets_task =
+            paginate(pagination, limit, stmt, sort_direction, asset::Column::Id).all(conn);
 
         let (assets, grand_total) = try_join!(assets_task, grand_total_task)?;
-        let full_assets = get_related_for_assets(conn, assets).await?;
+        let full_assets = get_related_for_assets(conn, assets, show_unverified_collections).await?;
         return Ok((full_assets, grand_total));
     } else {
-        let assets = paginate(pagination, limit, stmt).all(conn).await?;
-        let full_assets = get_related_for_assets(conn, assets).await?;
+        let assets = paginate(pagination, limit, stmt, sort_direction, asset::Column::Id)
+            .all(conn)
+            .await?;
+        let full_assets = get_related_for_assets(conn, assets, show_unverified_collections).await?;
         Ok((full_assets, None))
     }
 }
@@ -469,12 +534,12 @@ async fn get_grand_total(
 
 pub async fn add_collection_metadata(
     conn: &impl ConnectionTrait,
-    mut asset_list: AssetList,
-) -> Result<AssetList, DbErr> {
+    assets: &mut Vec<Asset>,
+) -> Result<(), DbErr> {
     // compile a set of all the distinct group values (bs58 String) from the asset list
     let mut group_values: HashSet<String> = HashSet::new();
-    for item in &asset_list.items {
-        if let Some(groups) = &item.grouping {
+    for asset in assets.iter() {
+        if let Some(groups) = &asset.grouping {
             for group in groups {
                 if let Some(group_value) = &group.group_value {
                     group_values.insert(group_value.clone());
@@ -508,14 +573,12 @@ pub async fn add_collection_metadata(
     }
 
     // add the metadata to the asset_list
-    for item in &mut asset_list.items {
-        if let Some(groups) = &mut item.grouping {
+    for asset in assets.iter_mut() {
+        if let Some(groups) = &mut asset.grouping {
             for group in groups {
                 if let Some(group_value) = &group.group_value {
                     let collection_metadata = hashmap.get(group_value);
                     if let Some(collection_metadata) = collection_metadata {
-                        group.group_key = group.group_key.clone();
-                        group.group_value = Some(group_value.clone());
                         group.collection_metadata = Some(collection_metadata.clone());
                     }
                 }
@@ -523,7 +586,7 @@ pub async fn add_collection_metadata(
         }
     }
 
-    Ok(asset_list)
+    Ok(())
 }
 
 fn get_collection_metadata(data: &asset_data::Model) -> CollectionMetadata {

--- a/digital_asset_types/src/dapi/assets_by_authority.rs
+++ b/digital_asset_types/src/dapi/assets_by_authority.rs
@@ -1,7 +1,9 @@
 use crate::dao::scopes;
+use crate::dao::PageOptions;
+use crate::feature_flag::FeatureFlags;
+use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
-use crate::rpc::transform::AssetTransform;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
@@ -12,30 +14,32 @@ pub async fn get_assets_by_authority(
     db: &DatabaseConnection,
     authority: Vec<u8>,
     sorting: AssetSorting,
-    limit: u64,
-    page: Option<u64>,
-    before: Option<Vec<u8>>,
-    after: Option<Vec<u8>>,
-    transform: &AssetTransform,
-    enable_grand_total_query: bool,
+    page_options: &PageOptions,
+    feature_flags: &FeatureFlags,
+    display_options: &DisplayOptions,
 ) -> Result<AssetList, DbErr> {
-    let pagination = create_pagination(before, after, page)?;
+    let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
+
+    let enable_grand_total_query =
+        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+
     let (assets, grand_total) = scopes::asset::get_by_authority(
         db,
         authority,
         sort_column,
         sort_direction,
         &pagination,
-        limit,
+        page_options.limit,
         enable_grand_total_query,
+        display_options.show_unverified_collections,
     )
     .await?;
     Ok(build_asset_response(
         assets,
-        limit,
+        page_options.limit,
         grand_total,
         &pagination,
-        transform,
+        display_options,
     ))
 }

--- a/digital_asset_types/src/dapi/assets_by_creator.rs
+++ b/digital_asset_types/src/dapi/assets_by_creator.rs
@@ -1,8 +1,9 @@
 use crate::dao::scopes;
+use crate::dao::PageOptions;
+use crate::feature_flag::FeatureFlags;
+use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
-
-use crate::rpc::transform::AssetTransform;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
@@ -13,15 +14,16 @@ pub async fn get_assets_by_creator(
     creator: Vec<u8>,
     only_verified: bool,
     sorting: AssetSorting,
-    limit: u64,
-    page: Option<u64>,
-    before: Option<Vec<u8>>,
-    after: Option<Vec<u8>>,
-    transform: &AssetTransform,
-    enable_grand_total_query: bool,
+    page_options: &PageOptions,
+    feature_flags: &FeatureFlags,
+    display_options: &DisplayOptions,
 ) -> Result<AssetList, DbErr> {
-    let pagination = create_pagination(before, after, page)?;
+    let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
+
+    let enable_grand_total_query =
+        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+
     let (assets, grand_total) = scopes::asset::get_by_creator(
         db,
         creator,
@@ -29,15 +31,16 @@ pub async fn get_assets_by_creator(
         sort_column,
         sort_direction,
         &pagination,
-        limit,
+        page_options.limit,
         enable_grand_total_query,
+        display_options.show_unverified_collections,
     )
     .await?;
     Ok(build_asset_response(
         assets,
-        limit,
+        page_options.limit,
         grand_total,
         &pagination,
-        transform,
+        display_options,
     ))
 }

--- a/digital_asset_types/src/dapi/assets_by_group.rs
+++ b/digital_asset_types/src/dapi/assets_by_group.rs
@@ -1,45 +1,47 @@
 use crate::dao::scopes;
+use crate::dao::PageOptions;
+use crate::feature_flag::FeatureFlags;
+use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
-
-use crate::rpc::transform::AssetTransform;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
 use super::common::create_sorting;
 use super::common::{build_asset_response, create_pagination};
+
 pub async fn get_assets_by_group(
     db: &DatabaseConnection,
-    group_key: String,
     group_value: String,
     sorting: AssetSorting,
-    limit: u64,
-    page: Option<u64>,
-    before: Option<Vec<u8>>,
-    after: Option<Vec<u8>>,
-    transform: &AssetTransform,
-    enable_grand_total_query: bool,
+    page_options: &PageOptions,
+    feature_flags: &FeatureFlags,
+    display_options: &DisplayOptions,
 ) -> Result<AssetList, DbErr> {
     // TODO: Explore further optimizing the unsorted query
-    let pagination = create_pagination(before, after, page)?;
+    let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
+
+    let enable_grand_total_query =
+        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+
     let (assets, grand_total) = scopes::asset::get_by_grouping(
         db,
-        group_key.clone(),
         group_value.clone(),
         sort_column,
         sort_direction,
         &pagination,
-        limit,
+        page_options.limit,
         enable_grand_total_query,
+        display_options.show_unverified_collections,
     )
     .await?;
 
     Ok(build_asset_response(
         assets,
-        limit,
+        page_options.limit,
         grand_total,
         &pagination,
-        transform,
+        display_options,
     ))
 }

--- a/digital_asset_types/src/dapi/assets_by_owner.rs
+++ b/digital_asset_types/src/dapi/assets_by_owner.rs
@@ -1,9 +1,9 @@
 use crate::dao::scopes;
-
+use crate::dao::PageOptions;
+use crate::feature_flag::FeatureFlags;
+use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
-use crate::rpc::transform::AssetTransform;
-
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 
@@ -13,30 +13,32 @@ pub async fn get_assets_by_owner(
     db: &DatabaseConnection,
     owner_address: Vec<u8>,
     sort_by: AssetSorting,
-    limit: u64,
-    page: Option<u64>,
-    before: Option<Vec<u8>>,
-    after: Option<Vec<u8>>,
-    transform: &AssetTransform,
-    enable_grand_total_query: bool,
+    page_options: &PageOptions,
+    feature_flags: &FeatureFlags,
+    display_options: &DisplayOptions,
 ) -> Result<AssetList, DbErr> {
-    let pagination = create_pagination(before, after, page)?;
+    let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sort_by);
+
+    let enable_grand_total_query =
+        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+
     let (assets, grand_total) = scopes::asset::get_assets_by_owner(
         db,
         owner_address,
         sort_column,
         sort_direction,
         &pagination,
-        limit,
+        page_options.limit,
         enable_grand_total_query,
+        display_options.show_unverified_collections,
     )
     .await?;
     Ok(build_asset_response(
         assets,
-        limit,
+        page_options.limit,
         grand_total,
         &pagination,
-        transform,
+        display_options,
     ))
 }

--- a/digital_asset_types/src/dapi/change_logs.rs
+++ b/digital_asset_types/src/dapi/change_logs.rs
@@ -1,6 +1,6 @@
-use log::debug;
 use sea_orm::sea_query::Expr;
 use sea_orm::{DatabaseConnection, DbBackend};
+use std::collections::HashMap;
 use {
     crate::dao::asset,
     crate::dao::cl_items,
@@ -15,9 +15,24 @@ struct SimpleChangeLog {
     level: i64,
     node_idx: i64,
     seq: i64,
+    tree: Vec<u8>,
 }
 
-pub async fn get_proof_for_asset(
+#[derive(FromQueryResult, Debug, Default, Clone, Eq, PartialEq)]
+struct LeafInfo {
+    id: Vec<u8>,
+    tree_id: Vec<u8>,
+    leaf_idx: i64,
+    node_idx: i64,
+    hash: Vec<u8>,
+}
+
+#[derive(Hash, Debug, Default, Clone, Eq, PartialEq)]
+struct Leaf {
+    tree_id: Vec<u8>,
+    leaf_idx: i64,
+}
+pub async fn get_asset_proof(
     db: &DatabaseConnection,
     asset_id: Vec<u8>,
 ) -> Result<AssetProof, DbErr> {
@@ -42,9 +57,6 @@ pub async fn get_proof_for_asset(
     }
     let leaf = leaf.unwrap();
     let req_indexes = get_required_nodes_for_proof(leaf.node_idx);
-    let expected_proof_size = req_indexes.len();
-    let mut final_node_list: Vec<SimpleChangeLog> =
-        vec![SimpleChangeLog::default(); expected_proof_size];
     let mut query = cl_items::Entity::find()
         .select_only()
         .column(cl_items::Column::NodeIdx)
@@ -61,48 +73,170 @@ pub async fn get_proof_for_asset(
     query.sql = query
         .sql
         .replace("SELECT", "SELECT DISTINCT ON (cl_items.node_idx)");
+    let required_nodes: Vec<SimpleChangeLog> = db.query_all(query).await.map(|qr| {
+        qr.iter()
+            .map(|q| SimpleChangeLog::from_query_result(q, "").unwrap())
+            .collect()
+    })?;
+    let asset_proof = build_asset_proof(
+        leaf.tree,
+        leaf.node_idx,
+        leaf.hash,
+        &req_indexes,
+        &required_nodes,
+    );
+    Ok(asset_proof)
+}
+
+pub async fn get_asset_proof_batch(
+    db: &DatabaseConnection,
+    asset_ids: Vec<Vec<u8>>,
+) -> Result<HashMap<String, AssetProof>, DbErr> {
+    // get the leaves (JOIN with `asset` table to get the asset ids)
+    let q = asset::Entity::find()
+        .join(
+            JoinType::InnerJoin,
+            asset::Entity::belongs_to(cl_items::Entity)
+                .from(asset::Column::Nonce)
+                .to(cl_items::Column::LeafIdx)
+                .into(),
+        )
+        // get only the necessary columns
+        .select_only()
+        .column(asset::Column::Id)
+        .column(asset::Column::TreeId)
+        .column(cl_items::Column::LeafIdx)
+        .column(cl_items::Column::NodeIdx)
+        .column(cl_items::Column::Hash)
+        .filter(Expr::cust("asset.tree_id = cl_items.tree"))
+        // filter by user provided asset ids
+        .filter(asset::Column::Id.is_in(asset_ids.clone()))
+        .build(DbBackend::Postgres);
+    let leaves: Vec<LeafInfo> = db.query_all(q).await.map(|qr| {
+        qr.iter()
+            .map(|q| LeafInfo::from_query_result(q, "").unwrap())
+            .collect()
+    })?;
+
+    let mut asset_map: HashMap<Leaf, LeafInfo> = HashMap::new();
+    for l in &leaves {
+        let key = Leaf {
+            tree_id: l.tree_id.clone(),
+            leaf_idx: l.leaf_idx,
+        };
+        asset_map.insert(key, l.clone());
+    }
+
+    // map: (tree_id, leaf_idx) -> [...req_indexes]
+    let mut tree_indexes: HashMap<Leaf, Vec<i64>> = HashMap::new();
+    for leaf in &leaves {
+        let key = Leaf {
+            tree_id: leaf.tree_id.clone(),
+            leaf_idx: leaf.leaf_idx,
+        };
+        let req_indexes = get_required_nodes_for_proof(leaf.node_idx);
+        tree_indexes.insert(key, req_indexes);
+    }
+
+    // get the required nodes for all assets
+    // SELECT * FROM cl_items WHERE (tree = ? AND node_idx IN (?)) OR (tree = ? AND node_idx IN (?)) OR ...
+    let mut condition = Condition::any();
+    for (leaf, req_indexes) in &tree_indexes {
+        let cond = Condition::all()
+            .add(cl_items::Column::Tree.eq(leaf.tree_id.clone()))
+            .add(cl_items::Column::NodeIdx.is_in(req_indexes.clone()));
+        condition = condition.add(cond);
+    }
+    let query = cl_items::Entity::find()
+        .select_only()
+        .column(cl_items::Column::Tree)
+        .column(cl_items::Column::NodeIdx)
+        .column(cl_items::Column::Level)
+        .column(cl_items::Column::Seq)
+        .column(cl_items::Column::Hash)
+        .filter(condition)
+        .build(DbBackend::Postgres);
     let nodes: Vec<SimpleChangeLog> = db.query_all(query).await.map(|qr| {
         qr.iter()
             .map(|q| SimpleChangeLog::from_query_result(q, "").unwrap())
             .collect()
     })?;
-    for node in nodes.iter() {
+
+    // map: (tree, node_idx) -> SimpleChangeLog
+    let mut node_map: HashMap<(Vec<u8>, i64), SimpleChangeLog> = HashMap::new();
+    for node in nodes {
+        let key = (node.tree.clone(), node.node_idx);
+        node_map.insert(key, node);
+    }
+
+    // construct the proofs
+    let mut asset_proofs: HashMap<String, AssetProof> = HashMap::new();
+    for (leaf, req_indexes) in &tree_indexes {
+        let required_nodes: Vec<SimpleChangeLog> = req_indexes
+            .iter()
+            .filter_map(|n| {
+                let key = (leaf.tree_id.clone(), *n);
+                node_map.get(&key).cloned()
+            })
+            .collect();
+
+        let leaf_info = asset_map.get(&leaf).unwrap();
+        let asset_proof = build_asset_proof(
+            leaf_info.tree_id.clone(),
+            leaf_info.node_idx,
+            leaf_info.hash.clone(),
+            &req_indexes,
+            &required_nodes,
+        );
+
+        let asset_id = bs58::encode(leaf_info.id.to_owned()).into_string();
+        asset_proofs.insert(asset_id, asset_proof);
+    }
+
+    Ok(asset_proofs)
+}
+
+fn build_asset_proof(
+    tree_id: Vec<u8>,
+    leaf_node_idx: i64,
+    leaf_hash: Vec<u8>,
+    req_indexes: &Vec<i64>,
+    required_nodes: &Vec<SimpleChangeLog>,
+) -> AssetProof {
+    let mut final_node_list = vec![SimpleChangeLog::default(); req_indexes.len()];
+    for node in required_nodes.iter() {
         if node.level < final_node_list.len().try_into().unwrap() {
             final_node_list[node.level as usize] = node.to_owned();
         }
     }
-    for (i, (n, nin)) in final_node_list.iter_mut().zip(req_indexes).enumerate() {
+    for (i, (n, nin)) in final_node_list
+        .iter_mut()
+        .zip(req_indexes.clone())
+        .enumerate()
+    {
         if *n == SimpleChangeLog::default() {
-            *n = make_empty_node(i as i64, nin);
+            *n = make_empty_node(i as i64, nin, tree_id.clone());
         }
     }
-    for n in final_node_list.iter() {
-        debug!(
-            "level {} index {} seq {} hash {}",
-            n.level,
-            n.node_idx,
-            n.seq,
-            bs58::encode(&n.hash).into_string()
-        );
-    }
-    Ok(AssetProof {
+    AssetProof {
         root: bs58::encode(final_node_list.pop().unwrap().hash).into_string(),
-        leaf: bs58::encode(&leaf.hash).into_string(),
+        leaf: bs58::encode(leaf_hash).into_string(),
         proof: final_node_list
             .iter()
             .map(|model| bs58::encode(&model.hash).into_string())
             .collect(),
-        node_index: leaf.node_idx,
-        tree_id: bs58::encode(&leaf.tree).into_string(),
-    })
+        node_index: leaf_node_idx,
+        tree_id: bs58::encode(tree_id).into_string(),
+    }
 }
 
-fn make_empty_node(lvl: i64, node_index: i64) -> SimpleChangeLog {
+fn make_empty_node(lvl: i64, node_index: i64, tree: Vec<u8>) -> SimpleChangeLog {
     SimpleChangeLog {
         node_idx: node_index,
         level: lvl,
         hash: empty_node(lvl as u32).to_vec(),
         seq: 0,
+        tree,
     }
 }
 

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -214,6 +214,10 @@ pub fn v1_content_from_json(
             meta.set_item("symbol", symbol.clone());
         }
     }
+    let token_standard = safe_select(chain_data_selector, "$.token_standard");
+    if let Some(token_standard) = token_standard {
+        meta.set_item("token_standard", token_standard.clone());
+    }
     let desc = safe_select(selector, "$.description");
     if let Some(desc) = desc {
         meta.set_item("description", desc.clone());

--- a/digital_asset_types/src/dapi/get_asset.rs
+++ b/digital_asset_types/src/dapi/get_asset.rs
@@ -1,18 +1,48 @@
-use sea_orm::{DatabaseConnection, DbErr};
+use std::collections::HashMap;
 
+use super::common::{asset_to_rpc, build_asset_response};
 use crate::{
-    dao::scopes,
-    rpc::{transform::AssetTransform, Asset},
+    dao::{
+        scopes::{self, asset::add_collection_metadata},
+        Pagination,
+    },
+    feature_flag::FeatureFlags,
+    rpc::{display_options::DisplayOptions, Asset},
 };
-
-use super::common::asset_to_rpc;
+use sea_orm::{DatabaseConnection, DbErr};
 
 pub async fn get_asset(
     db: &DatabaseConnection,
     id: Vec<u8>,
-    transform: &AssetTransform,
-    raw_data: Option<bool>,
+    feature_flags: &FeatureFlags,
+    display_options: &DisplayOptions,
 ) -> Result<Asset, DbErr> {
-    let asset = scopes::asset::get_by_id(db, id, false).await?;
-    asset_to_rpc(asset, transform, raw_data)
+    let asset = scopes::asset::get_by_id(db, id, false, display_options).await?;
+    let mut asset = asset_to_rpc(asset, display_options)?;
+    if display_options.show_collection_metadata && feature_flags.enable_collection_metadata {
+        let mut v = vec![asset.clone()];
+        add_collection_metadata(db, &mut v).await?;
+        asset = v.pop().unwrap_or(asset);
+    }
+    return Ok(asset);
+}
+
+pub async fn get_asset_batch(
+    db: &DatabaseConnection,
+    ids: Vec<Vec<u8>>,
+    limit: u64,
+    display_options: &DisplayOptions,
+) -> Result<HashMap<String, Asset>, DbErr> {
+    let pagination = Pagination::Page { page: 1 };
+    let assets = scopes::asset::get_asset_batch(db, ids, &pagination, limit).await?;
+    let mut asset_list = build_asset_response(assets, limit, None, &pagination, display_options);
+    if display_options.show_collection_metadata {
+        add_collection_metadata(db, &mut asset_list.items).await?;
+    }
+    let asset_map = asset_list
+        .items
+        .into_iter()
+        .map(|asset| (asset.id.clone(), asset))
+        .collect();
+    Ok(asset_map)
 }

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -2,9 +2,10 @@ use super::common::{build_asset_response, create_pagination, create_sorting};
 use crate::{
     dao::{
         scopes::{self, asset::add_collection_metadata},
-        SearchAssetsQuery,
+        PageOptions, SearchAssetsQuery,
     },
-    rpc::{filter::AssetSorting, response::AssetList, transform::AssetTransform},
+    feature_flag::FeatureFlags,
+    rpc::{display_options::DisplayOptions, filter::AssetSorting, response::AssetList},
 };
 use sea_orm::{DatabaseConnection, DbErr};
 
@@ -12,17 +13,17 @@ pub async fn search_assets(
     db: &DatabaseConnection,
     search_assets_query: SearchAssetsQuery,
     sorting: AssetSorting,
-    limit: u64,
-    page: Option<u64>,
-    before: Option<Vec<u8>>,
-    after: Option<Vec<u8>>,
-    transform: &AssetTransform,
-    enable_grand_total_query: bool,
-    enable_collection_metadata: bool,
+    page_options: &PageOptions,
+    feature_flags: &FeatureFlags,
+    display_options: &DisplayOptions,
 ) -> Result<AssetList, DbErr> {
-    let pagination = create_pagination(before, after, page)?;
+    let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
     let (condition, joins) = search_assets_query.conditions()?;
+
+    let enable_grand_total_query =
+        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+
     let (assets, grand_total) = scopes::asset::get_assets_by_condition(
         db,
         condition,
@@ -30,13 +31,20 @@ pub async fn search_assets(
         sort_column,
         sort_direction,
         &pagination,
-        limit,
+        page_options.limit,
         enable_grand_total_query,
+        display_options.show_unverified_collections,
     )
     .await?;
-    let mut asset_list = build_asset_response(assets, limit, grand_total, &pagination, &transform);
-    if enable_collection_metadata {
-        asset_list = add_collection_metadata(db, asset_list).await?;
+    let mut asset_list = build_asset_response(
+        assets,
+        page_options.limit,
+        grand_total,
+        &pagination,
+        display_options,
+    );
+    if display_options.show_collection_metadata {
+        add_collection_metadata(db, &mut asset_list.items).await?;
     }
     Ok(asset_list)
 }

--- a/digital_asset_types/src/dapi/signatures_for_asset.rs
+++ b/digital_asset_types/src/dapi/signatures_for_asset.rs
@@ -1,4 +1,5 @@
 use crate::dao::scopes;
+use crate::dao::PageOptions;
 
 use crate::rpc::response::TransactionSignatureList;
 use sea_orm::DatabaseConnection;
@@ -11,18 +12,21 @@ pub async fn get_signatures_for_asset(
     asset_id: Option<Vec<u8>>,
     tree: Option<Vec<u8>>,
     leaf_idx: Option<i64>,
-    limit: u64,
-    page: Option<u64>,
-    before: Option<Vec<u8>>,
-    after: Option<Vec<u8>>,
+    page_options: PageOptions,
 ) -> Result<TransactionSignatureList, DbErr> {
-    let pagination = create_pagination(before, after, page)?;
-    let transactions =
-        scopes::asset::get_signatures_for_asset(db, asset_id, tree, leaf_idx, &pagination, limit)
-            .await?;
+    let pagination = create_pagination(&page_options)?;
+    let transactions = scopes::asset::get_signatures_for_asset(
+        db,
+        asset_id,
+        tree,
+        leaf_idx,
+        &pagination,
+        page_options.limit,
+    )
+    .await?;
     Ok(build_transaction_signatures_response(
         transactions,
-        limit,
+        page_options.limit,
         &pagination,
     ))
 }

--- a/digital_asset_types/src/feature_flag.rs
+++ b/digital_asset_types/src/feature_flag.rs
@@ -1,0 +1,4 @@
+pub struct FeatureFlags {
+    pub enable_grand_total_query: bool,
+    pub enable_collection_metadata: bool,
+}

--- a/digital_asset_types/src/lib.rs
+++ b/digital_asset_types/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod dao;
 #[cfg(feature = "sql_types")]
 pub mod dapi;
+pub mod feature_flag;
 #[cfg(feature = "json_types")]
 pub mod json;
 #[cfg(feature = "json_types")]

--- a/digital_asset_types/src/rpc/asset.rs
+++ b/digital_asset_types/src/rpc/asset.rs
@@ -204,6 +204,8 @@ pub struct Group {
     pub group_key: String,
     pub group_value: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub collection_metadata: Option<CollectionMetadata>,
 }
 

--- a/digital_asset_types/src/rpc/display_options.rs
+++ b/digital_asset_types/src/rpc/display_options.rs
@@ -1,0 +1,18 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema, Default)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DisplayOptions {
+    #[serde(default)]
+    pub show_collection_metadata: bool,
+    #[serde(default)]
+    pub show_raw_data: bool,
+    #[serde(default)]
+    pub show_unverified_collections: bool,
+    #[serde(default)]
+    pub show_grand_total: bool,
+
+    #[serde(skip)]
+    pub cdn_prefix: Option<String>,
+}

--- a/digital_asset_types/src/rpc/filter.rs
+++ b/digital_asset_types/src/rpc/filter.rs
@@ -19,8 +19,9 @@ impl Default for AssetSorting {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-
 pub enum AssetSortBy {
+    #[serde(rename = "id")]
+    Id,
     #[serde(rename = "created")]
     Created,
     #[serde(rename = "updated")]

--- a/digital_asset_types/src/rpc/mod.rs
+++ b/digital_asset_types/src/rpc/mod.rs
@@ -1,5 +1,6 @@
 mod asset;
 
+pub mod display_options;
 pub mod filter;
 pub mod response;
 pub mod transform;

--- a/digital_asset_types/src/rpc/response.rs
+++ b/digital_asset_types/src/rpc/response.rs
@@ -22,7 +22,8 @@ pub struct GetGroupingResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(default)]
 pub struct AssetList {
-    // pub grand_total: u64, // TODO: not adding this for now because we aren't committing to the schema
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grand_total: Option<u64>,
     pub total: u32,
     pub limit: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -31,6 +32,8 @@ pub struct AssetList {
     pub before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
     pub items: Vec<Asset>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<AssetError>,
@@ -47,5 +50,5 @@ pub struct TransactionSignatureList {
     pub before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<String>,
-    pub items: Vec<Vec<String>>,
+    pub items: Vec<(String, String)>,
 }

--- a/migration/Cargo.lock
+++ b/migration/Cargo.lock
@@ -5598,33 +5598,3 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[patch.unused]]
-name = "anchor-lang"
-version = "0.25.0"
-source = "git+https://github.com/metaplex-foundation/anchor#b00fe70d1bb2bf38807bcb3a1987cfb14eb62058"
-
-[[patch.unused]]
-name = "blockbuster"
-version = "0.7.3"
-source = "git+https://github.com/metaplex-foundation/blockbuster?branch=1.14#e855eeb1f53030122afc9e3dd1b1124c818c64d6"
-
-[[patch.unused]]
-name = "mpl-bubblegum"
-version = "0.7.0"
-source = "git+https://github.com/metaplex-foundation/metaplex-program-library?branch=update-deps#94b06af274ba7eff1f02546b35dd922912d0136b"
-
-[[patch.unused]]
-name = "mpl-candy-guard"
-version = "0.3.0"
-source = "git+https://github.com/metaplex-foundation/mpl-candy-guard?branch=update-deps#7abc0b7640b807640850131d14214edbf12248bc"
-
-[[patch.unused]]
-name = "mpl-candy-machine-core"
-version = "0.2.0"
-source = "git+https://github.com/metaplex-foundation/metaplex-program-library?branch=update-deps#94b06af274ba7eff1f02546b35dd922912d0136b"
-
-[[patch.unused]]
-name = "mpl-token-metadata"
-version = "1.7.0"
-source = "git+https://github.com/metaplex-foundation/metaplex-program-library?branch=update-deps#94b06af274ba7eff1f02546b35dd922912d0136b"

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -9,22 +9,14 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "^1", features = ["attributes", "tokio1", ] }
-digital_asset_types = { path = "../digital_asset_types", features = ["json_types", "sql_types"] }
+async-std = { version = "^1", features = ["attributes", "tokio1"] }
+digital_asset_types = { path = "../digital_asset_types", features = [
+    "json_types",
+    "sql_types",
+] }
 enum-iterator = "1.2.0"
 enum-iterator-derive = "1.1.0"
 
 [dependencies.sea-orm-migration]
 version = "0.10.6"
-features = [
-    "runtime-tokio-rustls",
-    "sqlx-postgres",
-]
-
-[patch.crates-io]
-blockbuster = { git = "https://github.com/metaplex-foundation/blockbuster", branch="1.14" }
-anchor-lang = { git="https://github.com/metaplex-foundation/anchor" }
-mpl-token-metadata = { git="https://github.com/metaplex-foundation/metaplex-program-library", branch="update-deps"}
-mpl-candy-machine-core = { git="https://github.com/metaplex-foundation/metaplex-program-library", branch="update-deps"}
-mpl-candy-guard = { git="https://github.com/metaplex-foundation/mpl-candy-guard", branch="update-deps"}
-mpl-bubblegum = "=1.0.1-beta.2"
+features = ["runtime-tokio-rustls", "sqlx-postgres"]


### PR DESCRIPTION
- Add a new param `displayOptions` which can be used to opt-in for additional info.
- Allow users to see unverified collections via `displayOptions` opt-in. Also, getAssetsByGroup will return unverified collections if this flag is set.
- Add two new endpoints: `getAssetBatch` and `getAssetProofBatch`.
- New cursor-based keyset pagination method. The cursor is the same as the asset ID and behaves like the after option. When specified without any page options, it defaults to the cursor.
- Add `token_standard` in DAS response.
