### PR TITLE
rename method names and display_options

### DIFF
--- a/das_api/Cargo.toml
+++ b/das_api/Cargo.toml
@@ -6,24 +6,38 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-digital_asset_types = { path = "../digital_asset_types", features = ["json_types", "sql_types"] }
-jsonrpsee = {version = "0.16.2", features = ["server", "macros"]}
-jsonrpsee-core = {version = "0.16.2", features =["server"]}
-tower-http={version = "0.3.5", features = ["full"]}
-tower={version="0.4.13", features = ["full"]}
+digital_asset_types = { path = "../digital_asset_types", features = [
+    "json_types",
+    "sql_types",
+] }
+jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
+jsonrpsee-core = { version = "0.16.2", features = ["server"] }
+tower-http = { version = "0.3.5", features = ["full"] }
+tower = { version = "0.4.13", features = ["full"] }
 hyper = "0.14.23"
 tracing = "0.1.35"
 metrics = "0.20.1"
 figment = { version = "0.10.6", features = ["env"] }
 serde = "1.0.137"
 thiserror = "1.0.31"
-tokio = {version="1.23.0"}
+tokio = { version = "1.23.0" }
 async-trait = "0.1.56"
 serde_json = "1.0.81"
 cadence = "0.29.0"
 cadence-macros = "0.29.0"
-sqlx = { version = "0.6.2", features = ["macros", "runtime-tokio-rustls", "postgres", "uuid", "offline", "json"] }
-sea-orm = { version = "0.10.6", features = ["macros", "runtime-tokio-rustls", "sqlx-postgres"] }
+sqlx = { version = "0.6.2", features = [
+    "macros",
+    "runtime-tokio-rustls",
+    "postgres",
+    "uuid",
+    "offline",
+    "json",
+] }
+sea-orm = { version = "0.10.6", features = [
+    "macros",
+    "runtime-tokio-rustls",
+    "sqlx-postgres",
+] }
 tokio-postgres = "0.7.7"
 solana-sdk = "~1.16.16"
 bs58 = "0.4.0"
@@ -31,11 +45,11 @@ log = "0.4.17"
 env_logger = "0.10"
 schemars = "0.8.6"
 schemars_derive = "0.8.6"
-open-rpc-derive = { version = "0.0.4"}
-open-rpc-schema = { version = "0.0.4"}
+open-rpc-derive = { version = "0.0.4" }
+open-rpc-schema = { version = "0.0.4" }
 blockbuster = { git = "https://github.com/metaplex-foundation/blockbuster.git", rev = "e5d96d62969af42ce1c7f10cca88dc1c4f643598" }
 anchor-lang = "0.28.0"
-mpl-token-metadata = { version = "=2.0.0-beta.1",  features = ["serde-feature"] }
+mpl-token-metadata = { version = "=2.0.0-beta.1", features = ["serde-feature"] }
 mpl-candy-machine-core = { version = "2.0.1", features = ["no-entrypoint"] }
 mpl-bubblegum = "=1.0.1-beta.2"
 mpl-candy-guard = { version = "2.0.0", features = ["no-entrypoint"] }

--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -232,11 +232,11 @@ impl ApiContract for DasApi {
             .map_err(Into::into)
     }
 
-    async fn get_asset_proof_batch(
+    async fn get_asset_proofs(
         self: &DasApi,
-        payload: GetAssetProofBatch,
+        payload: GetAssetProofs,
     ) -> Result<HashMap<String, Option<AssetProof>>, DasApiError> {
-        let GetAssetProofBatch { ids } = payload;
+        let GetAssetProofs { ids } = payload;
 
         let batch_size = ids.len();
         if batch_size > 1000 {
@@ -258,31 +258,25 @@ impl ApiContract for DasApi {
     }
 
     async fn get_asset(self: &DasApi, payload: GetAsset) -> Result<Asset, DasApiError> {
-        let GetAsset {
-            id,
-            display_options,
-        } = payload;
+        let GetAsset { id, options } = payload;
         let id_bytes = validate_pubkey(id.clone())?.to_bytes().to_vec();
-        let mut display_options = display_options.unwrap_or_default();
-        display_options.cdn_prefix = self.cdn_prefix.clone();
+        let mut options = options.unwrap_or_default();
+        options.cdn_prefix = self.cdn_prefix.clone();
         get_asset(
             &self.db_connection,
             id_bytes,
             &self.feature_flags,
-            &display_options.into(),
+            &options.into(),
         )
         .await
         .map_err(Into::into)
     }
 
-    async fn get_asset_batch(
+    async fn get_assets(
         self: &DasApi,
-        payload: GetAssetBatch,
+        payload: GetAssets,
     ) -> Result<Vec<Option<Asset>>, DasApiError> {
-        let GetAssetBatch {
-            ids,
-            display_options,
-        } = payload;
+        let GetAssets { ids, options } = payload;
 
         let batch_size = ids.len();
         if batch_size > 1000 {
@@ -294,14 +288,14 @@ impl ApiContract for DasApi {
             .map(|id| validate_pubkey(id.clone()).map(|id| id.to_bytes().to_vec()))
             .collect::<Result<Vec<Vec<u8>>, _>>()?;
 
-        let mut display_options = display_options.unwrap_or_default();
-        display_options.cdn_prefix = self.cdn_prefix.clone();
+        let mut options = options.unwrap_or_default();
+        options.cdn_prefix = self.cdn_prefix.clone();
 
         let assets = get_asset_batch(
             &self.db_connection,
             id_bytes,
             batch_size as u64,
-            &display_options.into(),
+            &options.into(),
         )
         .await?;
 
@@ -320,7 +314,7 @@ impl ApiContract for DasApi {
             page,
             before,
             after,
-            display_options,
+            options,
             cursor,
         } = payload;
         let before: Option<String> = before.filter(|before| !before.is_empty());
@@ -330,15 +324,15 @@ impl ApiContract for DasApi {
         let sort_by = sort_by.unwrap_or_default();
         let page_options =
             self.validate_pagination(&limit, &page, &before, &after, &cursor, &Some(&sort_by))?;
-        let mut display_options = display_options.unwrap_or_default();
-        display_options.cdn_prefix = self.cdn_prefix.clone();
+        let mut options = options.unwrap_or_default();
+        options.cdn_prefix = self.cdn_prefix.clone();
         get_assets_by_owner(
             &self.db_connection,
             owner_address_bytes,
             sort_by,
             &page_options,
             &self.feature_flags,
-            &display_options,
+            &options,
         )
         .await
         .map_err(Into::into)
@@ -356,7 +350,7 @@ impl ApiContract for DasApi {
             page,
             before,
             after,
-            display_options,
+            options,
             cursor,
         } = payload;
         self.validate_sorting_for_collection(&group_key, &group_value, &sort_by)?;
@@ -365,15 +359,15 @@ impl ApiContract for DasApi {
         let sort_by = sort_by.unwrap_or_default();
         let page_options =
             self.validate_pagination(&limit, &page, &before, &after, &cursor, &Some(&sort_by))?;
-        let mut display_options = display_options.unwrap_or_default();
-        display_options.cdn_prefix = self.cdn_prefix.clone();
+        let mut options = options.unwrap_or_default();
+        options.cdn_prefix = self.cdn_prefix.clone();
         get_assets_by_group(
             &self.db_connection,
             group_value,
             sort_by,
             &page_options,
             &self.feature_flags,
-            &display_options,
+            &options,
         )
         .await
         .map_err(Into::into)
@@ -391,7 +385,7 @@ impl ApiContract for DasApi {
             page,
             before,
             after,
-            display_options,
+            options,
             cursor,
         } = payload;
         let creator_address = validate_pubkey(creator_address.clone())?;
@@ -401,8 +395,8 @@ impl ApiContract for DasApi {
         let page_options =
             self.validate_pagination(&limit, &page, &before, &after, &cursor, &Some(&sort_by))?;
         let only_verified = only_verified.unwrap_or_default();
-        let mut display_options = display_options.unwrap_or_default();
-        display_options.cdn_prefix = self.cdn_prefix.clone();
+        let mut options = options.unwrap_or_default();
+        options.cdn_prefix = self.cdn_prefix.clone();
         get_assets_by_creator(
             &self.db_connection,
             creator_address_bytes,
@@ -410,7 +404,7 @@ impl ApiContract for DasApi {
             sort_by,
             &page_options,
             &self.feature_flags,
-            &display_options,
+            &options,
         )
         .await
         .map_err(Into::into)
@@ -427,7 +421,7 @@ impl ApiContract for DasApi {
             page,
             before,
             after,
-            display_options,
+            options,
             cursor,
         } = payload;
         let authority_address = validate_pubkey(authority_address.clone())?;
@@ -435,15 +429,15 @@ impl ApiContract for DasApi {
         let sort_by = sort_by.unwrap_or_default();
         let page_options =
             self.validate_pagination(&limit, &page, &before, &after, &cursor, &Some(&sort_by))?;
-        let mut display_options = display_options.unwrap_or_default();
-        display_options.cdn_prefix = self.cdn_prefix.clone();
+        let mut options = options.unwrap_or_default();
+        options.cdn_prefix = self.cdn_prefix.clone();
         get_assets_by_authority(
             &self.db_connection,
             authority_address_bytes,
             sort_by,
             &page_options,
             &self.feature_flags,
-            &display_options,
+            &options,
         )
         .await
         .map_err(Into::into)
@@ -477,7 +471,7 @@ impl ApiContract for DasApi {
             before,
             after,
             json_uri,
-            display_options,
+            options,
             cursor,
             name,
         } = payload;
@@ -535,8 +529,8 @@ impl ApiContract for DasApi {
         let sort_by = sort_by.unwrap_or_default();
         let page_options =
             self.validate_pagination(&limit, &page, &before, &after, &cursor, &Some(&sort_by))?;
-        let mut display_options = display_options.unwrap_or_default();
-        display_options.cdn_prefix = self.cdn_prefix.clone();
+        let mut options = options.unwrap_or_default();
+        options.cdn_prefix = self.cdn_prefix.clone();
         // Execute query
         search_assets(
             &self.db_connection,
@@ -544,7 +538,7 @@ impl ApiContract for DasApi {
             sort_by,
             &page_options,
             &self.feature_flags,
-            &display_options,
+            &options,
         )
         .await
         .map_err(Into::into)

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -1,7 +1,7 @@
 use crate::DasApiError;
 use async_trait::async_trait;
-use digital_asset_types::rpc::display_options::DisplayOptions;
 use digital_asset_types::rpc::filter::SearchConditionType;
+use digital_asset_types::rpc::options::Options;
 use digital_asset_types::rpc::response::{AssetList, TransactionSignatureList};
 use digital_asset_types::rpc::{filter::AssetSorting, response::GetGroupingResponse};
 use digital_asset_types::rpc::{Asset, AssetProof, Interface, OwnershipModel, RoyaltyModel};
@@ -23,8 +23,8 @@ pub struct GetAssetsByGroup {
     pub page: Option<u32>,
     pub before: Option<String>,
     pub after: Option<String>,
-    #[serde(default)]
-    pub display_options: Option<DisplayOptions>,
+    #[serde(default, alias = "displayOptions")]
+    pub options: Option<Options>,
     #[serde(default)]
     pub cursor: Option<String>,
 }
@@ -38,8 +38,8 @@ pub struct GetAssetsByOwner {
     pub page: Option<u32>,
     pub before: Option<String>,
     pub after: Option<String>,
-    #[serde(default)]
-    pub display_options: Option<DisplayOptions>,
+    #[serde(default, alias = "displayOptions")]
+    pub options: Option<Options>,
     #[serde(default)]
     pub cursor: Option<String>,
 }
@@ -48,16 +48,16 @@ pub struct GetAssetsByOwner {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct GetAsset {
     pub id: String,
-    #[serde(default)]
-    pub display_options: Option<DisplayOptions>,
+    #[serde(default, alias = "displayOptions")]
+    pub options: Option<Options>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct GetAssetBatch {
+pub struct GetAssets {
     pub ids: Vec<String>,
-    #[serde(default)]
-    pub display_options: Option<DisplayOptions>,
+    #[serde(default, alias = "displayOptions")]
+    pub options: Option<Options>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -68,7 +68,7 @@ pub struct GetAssetProof {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct GetAssetProofBatch {
+pub struct GetAssetProofs {
     pub ids: Vec<String>,
 }
 
@@ -82,8 +82,8 @@ pub struct GetAssetsByCreator {
     pub page: Option<u32>,
     pub before: Option<String>,
     pub after: Option<String>,
-    #[serde(default)]
-    pub display_options: Option<DisplayOptions>,
+    #[serde(default, alias = "displayOptions")]
+    pub options: Option<Options>,
     #[serde(default)]
     pub cursor: Option<String>,
 }
@@ -117,8 +117,8 @@ pub struct SearchAssets {
     pub after: Option<String>,
     #[serde(default)]
     pub json_uri: Option<String>,
-    #[serde(default)]
-    pub display_options: Option<DisplayOptions>,
+    #[serde(default, alias = "displayOptions")]
+    pub options: Option<Options>,
     #[serde(default)]
     pub cursor: Option<String>,
     #[serde(default)]
@@ -135,8 +135,8 @@ pub struct GetAssetsByAuthority {
     pub page: Option<u32>,
     pub before: Option<String>,
     pub after: Option<String>,
-    #[serde(default)]
-    pub display_options: Option<DisplayOptions>,
+    #[serde(default, alias = "displayOptions")]
+    pub options: Option<Options>,
     #[serde(default)]
     pub cursor: Option<String>,
 }
@@ -173,13 +173,13 @@ pub trait ApiContract: Send + Sync + 'static {
     )]
     async fn get_asset_proof(&self, payload: GetAssetProof) -> Result<AssetProof, DasApiError>;
     #[rpc(
-        name = "getAssetProofBatch",
+        name = "getAssetProofs",
         params = "named",
         summary = "Get merkle proofs for compressed assets by their IDs"
     )]
-    async fn get_asset_proof_batch(
+    async fn get_asset_proofs(
         &self,
-        payload: GetAssetProofBatch,
+        payload: GetAssetProofs,
     ) -> Result<HashMap<String, Option<AssetProof>>, DasApiError>;
     #[rpc(
         name = "getAsset",
@@ -188,14 +188,11 @@ pub trait ApiContract: Send + Sync + 'static {
     )]
     async fn get_asset(&self, payload: GetAsset) -> Result<Asset, DasApiError>;
     #[rpc(
-        name = "getAssetBatch",
+        name = "getAssets",
         params = "named",
         summary = "Get assets by their IDs"
     )]
-    async fn get_asset_batch(
-        &self,
-        payload: GetAssetBatch,
-    ) -> Result<Vec<Option<Asset>>, DasApiError>;
+    async fn get_assets(&self, payload: GetAssets) -> Result<Vec<Option<Asset>>, DasApiError>;
     #[rpc(
         name = "getAssetsByOwner",
         params = "named",

--- a/das_api/src/builder.rs
+++ b/das_api/src/builder.rs
@@ -22,17 +22,16 @@ impl RpcApiBuilder {
         })?;
         module.register_alias("getAssetProof", "get_asset_proof")?;
 
-        module.register_async_method(
-            "get_asset_proof_batch",
-            |rpc_params, rpc_context| async move {
-                let payload = rpc_params.parse::<GetAssetProofBatch>()?;
-                rpc_context
-                    .get_asset_proof_batch(payload)
-                    .await
-                    .map_err(Into::into)
-            },
-        )?;
-        module.register_alias("getAssetProofBatch", "get_asset_proof_batch")?;
+        module.register_async_method("get_asset_proofs", |rpc_params, rpc_context| async move {
+            let payload = rpc_params.parse::<GetAssetProofs>()?;
+            rpc_context
+                .get_asset_proofs(payload)
+                .await
+                .map_err(Into::into)
+        })?;
+        module.register_alias("getAssetProofs", "get_asset_proofs")?;
+        module.register_alias("get_asset_proof_batch", "get_asset_proofs")?;
+        module.register_alias("getAssetProofBatch", "get_asset_proofs")?;
 
         module.register_async_method("get_asset", |rpc_params, rpc_context| async move {
             let payload = rpc_params.parse::<GetAsset>()?;
@@ -40,14 +39,13 @@ impl RpcApiBuilder {
         })?;
         module.register_alias("getAsset", "get_asset")?;
 
-        module.register_async_method("get_asset_batch", |rpc_params, rpc_context| async move {
-            let payload = rpc_params.parse::<GetAssetBatch>()?;
-            rpc_context
-                .get_asset_batch(payload)
-                .await
-                .map_err(Into::into)
+        module.register_async_method("get_assets", |rpc_params, rpc_context| async move {
+            let payload = rpc_params.parse::<GetAssets>()?;
+            rpc_context.get_assets(payload).await.map_err(Into::into)
         })?;
-        module.register_alias("getAssetBatch", "get_asset_batch")?;
+        module.register_alias("getAssets", "get_assets")?;
+        module.register_alias("get_asset_batch", "get_assets")?;
+        module.register_alias("getAssetBatch", "get_assets")?;
 
         module.register_async_method(
             "get_assets_by_owner",

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -5,7 +5,7 @@ use crate::{
         GroupingSize, Pagination,
     },
     dapi::common::safe_select,
-    rpc::{display_options::DisplayOptions, Asset, CollectionMetadata},
+    rpc::{options::Options, Asset, CollectionMetadata},
 };
 
 use indexmap::IndexMap;
@@ -380,7 +380,7 @@ pub async fn get_by_id(
     conn: &impl ConnectionTrait,
     asset_id: Vec<u8>,
     include_no_supply: bool,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<FullAsset, DbErr> {
     let mut asset_data =
         asset::Entity::find_by_id(asset_id.clone()).find_also_related(asset_data::Entity);
@@ -404,7 +404,7 @@ pub async fn get_by_id(
         .order_by_asc(asset_creators::Column::Position)
         .all(conn)
         .await?;
-    let cond = if display_options.show_unverified_collections {
+    let cond = if options.show_unverified_collections {
         Condition::all()
     } else {
         Condition::any()

--- a/digital_asset_types/src/dapi/assets_by_authority.rs
+++ b/digital_asset_types/src/dapi/assets_by_authority.rs
@@ -1,8 +1,8 @@
 use crate::dao::scopes;
 use crate::dao::PageOptions;
 use crate::feature_flag::FeatureFlags;
-use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
+use crate::rpc::options::Options;
 use crate::rpc::response::AssetList;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
@@ -16,13 +16,13 @@ pub async fn get_assets_by_authority(
     sorting: AssetSorting,
     page_options: &PageOptions,
     feature_flags: &FeatureFlags,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
 
     let enable_grand_total_query =
-        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+        feature_flags.enable_grand_total_query && options.show_grand_total;
 
     let (assets, grand_total) = scopes::asset::get_by_authority(
         db,
@@ -32,7 +32,7 @@ pub async fn get_assets_by_authority(
         &pagination,
         page_options.limit,
         enable_grand_total_query,
-        display_options.show_unverified_collections,
+        options.show_unverified_collections,
     )
     .await?;
     Ok(build_asset_response(
@@ -40,6 +40,6 @@ pub async fn get_assets_by_authority(
         page_options.limit,
         grand_total,
         &pagination,
-        display_options,
+        options,
     ))
 }

--- a/digital_asset_types/src/dapi/assets_by_creator.rs
+++ b/digital_asset_types/src/dapi/assets_by_creator.rs
@@ -1,8 +1,8 @@
 use crate::dao::scopes;
 use crate::dao::PageOptions;
 use crate::feature_flag::FeatureFlags;
-use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
+use crate::rpc::options::Options;
 use crate::rpc::response::AssetList;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
@@ -16,13 +16,13 @@ pub async fn get_assets_by_creator(
     sorting: AssetSorting,
     page_options: &PageOptions,
     feature_flags: &FeatureFlags,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
 
     let enable_grand_total_query =
-        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+        feature_flags.enable_grand_total_query && options.show_grand_total;
 
     let (assets, grand_total) = scopes::asset::get_by_creator(
         db,
@@ -33,7 +33,7 @@ pub async fn get_assets_by_creator(
         &pagination,
         page_options.limit,
         enable_grand_total_query,
-        display_options.show_unverified_collections,
+        options.show_unverified_collections,
     )
     .await?;
     Ok(build_asset_response(
@@ -41,6 +41,6 @@ pub async fn get_assets_by_creator(
         page_options.limit,
         grand_total,
         &pagination,
-        display_options,
+        options,
     ))
 }

--- a/digital_asset_types/src/dapi/assets_by_group.rs
+++ b/digital_asset_types/src/dapi/assets_by_group.rs
@@ -1,8 +1,8 @@
 use crate::dao::scopes;
 use crate::dao::PageOptions;
 use crate::feature_flag::FeatureFlags;
-use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
+use crate::rpc::options::Options;
 use crate::rpc::response::AssetList;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
@@ -16,14 +16,14 @@ pub async fn get_assets_by_group(
     sorting: AssetSorting,
     page_options: &PageOptions,
     feature_flags: &FeatureFlags,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<AssetList, DbErr> {
     // TODO: Explore further optimizing the unsorted query
     let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
 
     let enable_grand_total_query =
-        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+        feature_flags.enable_grand_total_query && options.show_grand_total;
 
     let (assets, grand_total) = scopes::asset::get_by_grouping(
         db,
@@ -33,7 +33,7 @@ pub async fn get_assets_by_group(
         &pagination,
         page_options.limit,
         enable_grand_total_query,
-        display_options.show_unverified_collections,
+        options.show_unverified_collections,
     )
     .await?;
 
@@ -42,6 +42,6 @@ pub async fn get_assets_by_group(
         page_options.limit,
         grand_total,
         &pagination,
-        display_options,
+        options,
     ))
 }

--- a/digital_asset_types/src/dapi/assets_by_owner.rs
+++ b/digital_asset_types/src/dapi/assets_by_owner.rs
@@ -1,8 +1,8 @@
 use crate::dao::scopes;
 use crate::dao::PageOptions;
 use crate::feature_flag::FeatureFlags;
-use crate::rpc::display_options::DisplayOptions;
 use crate::rpc::filter::AssetSorting;
+use crate::rpc::options::Options;
 use crate::rpc::response::AssetList;
 use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
@@ -15,13 +15,13 @@ pub async fn get_assets_by_owner(
     sort_by: AssetSorting,
     page_options: &PageOptions,
     feature_flags: &FeatureFlags,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sort_by);
 
     let enable_grand_total_query =
-        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+        feature_flags.enable_grand_total_query && options.show_grand_total;
 
     let (assets, grand_total) = scopes::asset::get_assets_by_owner(
         db,
@@ -31,7 +31,7 @@ pub async fn get_assets_by_owner(
         &pagination,
         page_options.limit,
         enable_grand_total_query,
-        display_options.show_unverified_collections,
+        options.show_unverified_collections,
     )
     .await?;
     Ok(build_asset_response(
@@ -39,6 +39,6 @@ pub async fn get_assets_by_owner(
         page_options.limit,
         grand_total,
         &pagination,
-        display_options,
+        options,
     ))
 }

--- a/digital_asset_types/src/dapi/get_asset.rs
+++ b/digital_asset_types/src/dapi/get_asset.rs
@@ -7,7 +7,7 @@ use crate::{
         Pagination,
     },
     feature_flag::FeatureFlags,
-    rpc::{display_options::DisplayOptions, Asset},
+    rpc::{options::Options, Asset},
 };
 use sea_orm::{DatabaseConnection, DbErr};
 
@@ -15,11 +15,11 @@ pub async fn get_asset(
     db: &DatabaseConnection,
     id: Vec<u8>,
     feature_flags: &FeatureFlags,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<Asset, DbErr> {
-    let asset = scopes::asset::get_by_id(db, id, false, display_options).await?;
-    let mut asset = asset_to_rpc(asset, display_options)?;
-    if display_options.show_collection_metadata && feature_flags.enable_collection_metadata {
+    let asset = scopes::asset::get_by_id(db, id, false, options).await?;
+    let mut asset = asset_to_rpc(asset, options)?;
+    if options.show_collection_metadata && feature_flags.enable_collection_metadata {
         let mut v = vec![asset.clone()];
         add_collection_metadata(db, &mut v).await?;
         asset = v.pop().unwrap_or(asset);
@@ -31,12 +31,12 @@ pub async fn get_asset_batch(
     db: &DatabaseConnection,
     ids: Vec<Vec<u8>>,
     limit: u64,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<HashMap<String, Asset>, DbErr> {
     let pagination = Pagination::Page { page: 1 };
     let assets = scopes::asset::get_asset_batch(db, ids, &pagination, limit).await?;
-    let mut asset_list = build_asset_response(assets, limit, None, &pagination, display_options);
-    if display_options.show_collection_metadata {
+    let mut asset_list = build_asset_response(assets, limit, None, &pagination, options);
+    if options.show_collection_metadata {
         add_collection_metadata(db, &mut asset_list.items).await?;
     }
     let asset_map = asset_list

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -5,7 +5,7 @@ use crate::{
         PageOptions, SearchAssetsQuery,
     },
     feature_flag::FeatureFlags,
-    rpc::{display_options::DisplayOptions, filter::AssetSorting, response::AssetList},
+    rpc::{filter::AssetSorting, options::Options, response::AssetList},
 };
 use sea_orm::{DatabaseConnection, DbErr};
 
@@ -15,14 +15,14 @@ pub async fn search_assets(
     sorting: AssetSorting,
     page_options: &PageOptions,
     feature_flags: &FeatureFlags,
-    display_options: &DisplayOptions,
+    options: &Options,
 ) -> Result<AssetList, DbErr> {
     let pagination = create_pagination(&page_options)?;
     let (sort_direction, sort_column) = create_sorting(sorting);
     let (condition, joins) = search_assets_query.conditions()?;
 
     let enable_grand_total_query =
-        feature_flags.enable_grand_total_query && display_options.show_grand_total;
+        feature_flags.enable_grand_total_query && options.show_grand_total;
 
     let (assets, grand_total) = scopes::asset::get_assets_by_condition(
         db,
@@ -33,7 +33,7 @@ pub async fn search_assets(
         &pagination,
         page_options.limit,
         enable_grand_total_query,
-        display_options.show_unverified_collections,
+        options.show_unverified_collections,
     )
     .await?;
     let mut asset_list = build_asset_response(
@@ -41,9 +41,9 @@ pub async fn search_assets(
         page_options.limit,
         grand_total,
         &pagination,
-        display_options,
+        options,
     );
-    if display_options.show_collection_metadata {
+    if options.show_collection_metadata {
         add_collection_metadata(db, &mut asset_list.items).await?;
     }
     Ok(asset_list)

--- a/digital_asset_types/src/rpc/mod.rs
+++ b/digital_asset_types/src/rpc/mod.rs
@@ -1,7 +1,7 @@
 mod asset;
 
-pub mod display_options;
 pub mod filter;
+pub mod options;
 pub mod response;
 pub mod transform;
 

--- a/digital_asset_types/src/rpc/options.rs
+++ b/digital_asset_types/src/rpc/options.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct DisplayOptions {
+pub struct Options {
     #[serde(default)]
     pub show_collection_metadata: bool,
     #[serde(default)]

--- a/digital_asset_types/tests/json_parsing.rs
+++ b/digital_asset_types/tests/json_parsing.rs
@@ -4,7 +4,7 @@ use digital_asset_types::dao::asset_data;
 use digital_asset_types::dao::sea_orm_active_enums::{ChainMutability, Mutability};
 use digital_asset_types::dapi::common::v1_content_from_json;
 use digital_asset_types::json::ChainDataV1;
-use digital_asset_types::rpc::display_options::DisplayOptions;
+use digital_asset_types::rpc::options::Options;
 use digital_asset_types::rpc::Content;
 use digital_asset_types::rpc::File;
 use solana_sdk::signature::Keypair;
@@ -17,10 +17,7 @@ pub async fn load_test_json(file_name: &str) -> serde_json::Value {
     serde_json::from_str(&json).unwrap()
 }
 
-pub async fn parse_onchain_json(
-    json: serde_json::Value,
-    display_options: &DisplayOptions,
-) -> Content {
+pub async fn parse_onchain_json(json: serde_json::Value, options: &Options) -> Content {
     let asset_data = asset_data::Model {
         id: Keypair::new().pubkey().to_bytes().to_vec(),
         chain_data_mutability: ChainMutability::Mutable,
@@ -42,17 +39,17 @@ pub async fn parse_onchain_json(
         raw_symbol: Some(String::from("  ").into_bytes().to_vec()),
     };
 
-    v1_content_from_json(&asset_data, display_options).unwrap()
+    v1_content_from_json(&asset_data, options).unwrap()
 }
 
 #[tokio::test]
 async fn simple_content() {
-    let mut display_options = DisplayOptions::default();
+    let mut options = Options::default();
 
-    display_options.cdn_prefix = None;
-    display_options.show_raw_data = true;
+    options.cdn_prefix = None;
+    options.show_raw_data = true;
     let j = load_test_json("mad_lad.json").await;
-    let mut parsed = parse_onchain_json(j.clone(), &display_options).await;
+    let mut parsed = parse_onchain_json(j.clone(), &options).await;
     assert_eq!(
         parsed.files,
         Some(vec![
@@ -86,9 +83,9 @@ async fn simple_content() {
         _ => panic!("symbol key not found or not a string"),
     }
 
-    display_options.cdn_prefix = None;
-    display_options.show_raw_data = false;
-    parsed = parse_onchain_json(j.clone(), &display_options).await;
+    options.cdn_prefix = None;
+    options.show_raw_data = false;
+    parsed = parse_onchain_json(j.clone(), &options).await;
 
     match parsed.metadata.get_item("name") {
         Some(serde_json::Value::String(name)) => assert_eq!(name, "Handalf"),
@@ -126,11 +123,11 @@ async fn simple_content() {
 
 #[tokio::test]
 async fn simple_content_with_cdn() {
-    let mut display_options = DisplayOptions::default();
-    display_options.cdn_prefix = Some("https://cdn.foobar.blah".to_string());
+    let mut options = Options::default();
+    options.cdn_prefix = Some("https://cdn.foobar.blah".to_string());
 
     let j = load_test_json("mad_lad.json").await;
-    let parsed = parse_onchain_json(j, &display_options).await;
+    let parsed = parse_onchain_json(j, &options).await;
     assert_eq!(
         parsed.files,
         Some(vec![
@@ -157,10 +154,10 @@ async fn simple_content_with_cdn() {
 
 #[tokio::test]
 async fn complex_content() {
-    let mut display_options = DisplayOptions::default();
-    display_options.cdn_prefix = None;
+    let mut options = Options::default();
+    options.cdn_prefix = None;
     let j = load_test_json("infinite_fungi.json").await;
-    let parsed = parse_onchain_json(j, &display_options).await;
+    let parsed = parse_onchain_json(j, &options).await;
     assert_eq!(
         parsed.files,
         Some(vec![
@@ -212,10 +209,10 @@ async fn complex_content() {
 
 #[tokio::test]
 async fn complex_content_with_cdn() {
-    let mut display_options = DisplayOptions::default();
-    display_options.cdn_prefix = Some("https://cdn.foobar.blah".to_string());
+    let mut options = Options::default();
+    options.cdn_prefix = Some("https://cdn.foobar.blah".to_string());
     let j = load_test_json("infinite_fungi.json").await;
-    let parsed = parse_onchain_json(j, &display_options).await;
+    let parsed = parse_onchain_json(j, &options).await;
     assert_eq!(
         parsed.files,
         Some(vec![


### PR DESCRIPTION
## Overview
- Rename the methods `getAssetbatch` and `getAssetProofBatch` to `getAssets` and `getAssetProofs`.
- Rename `displayOptions` to `options`.
- Add aliases for the above for backward compatibility.

## Testing
-   Testing performed to validate the changes
